### PR TITLE
Sage300 - Polling States (Dashboard) - 2

### DIFF
--- a/src/app/core/models/enum/enum.model.ts
+++ b/src/app/core/models/enum/enum.model.ts
@@ -427,7 +427,8 @@ export enum QBDOnboardingState {
     FATAL = 'FATAL',
     COMPLETE = 'COMPLETE',
     IN_PROGRESS = 'IN_PROGRESS',
-    ENQUEUED = 'ENQUEUED'
+    ENQUEUED = 'ENQUEUED',
+    EXPORT_QUEUED = 'EXPORT_QUEUED'
   }
 
   export enum AccountingExportType {

--- a/src/app/integrations/sage300/sage300-main/sage300-dashboard/sage300-dashboard.component.ts
+++ b/src/app/integrations/sage300/sage300-main/sage300-dashboard/sage300-dashboard.component.ts
@@ -57,14 +57,14 @@ export class Sage300DashboardComponent implements OnInit {
       switchMap(() => from(this.accountingExportService.getAccountingExports([], exportableAccountingExportIds, 500, 0))),
       takeWhile((response: AccountingExportResponse) =>
         response.results.filter(task =>
-          (task.status === AccountingExportStatus.IN_PROGRESS || task.status === AccountingExportStatus.ENQUEUED || AccountingExportStatus.EXPORT_QUEUED) && exportableAccountingExportIds.includes(task.expense_group)
+          (task.status === AccountingExportStatus.IN_PROGRESS || task.status === AccountingExportStatus.ENQUEUED || task.status === AccountingExportStatus.EXPORT_QUEUED) && exportableAccountingExportIds.includes(task.expense_group)
         ).length > 0, true
       )
     ).subscribe((res: AccountingExportResponse) => {
       this.processedCount = res.results.filter(task => (task.status !== AccountingExportStatus.IN_PROGRESS && task.status !== AccountingExportStatus.ENQUEUED && task.status !== AccountingExportStatus.EXPORT_QUEUED)).length;
       this.exportProgressPercentage = Math.round((this.processedCount / this.exportableAccountingExportIds.length) * 100);
 
-      if (res.results.filter(task => (task.status === AccountingExportStatus.IN_PROGRESS || task.status === AccountingExportStatus.ENQUEUED || AccountingExportStatus.EXPORT_QUEUED) && exportableAccountingExportIds.includes(task.expense_group)).length === 0) {
+      if (res.results.filter(task => (task.status === AccountingExportStatus.IN_PROGRESS || task.status === AccountingExportStatus.ENQUEUED || task.status === AccountingExportStatus.EXPORT_QUEUED) && exportableAccountingExportIds.includes(task.expense_group)).length === 0) {
         this.isLoading = true;
         forkJoin([
           this.getExportErrors$,
@@ -109,7 +109,7 @@ export class Sage300DashboardComponent implements OnInit {
       this.errors = DashboardModel.parseAPIResponseToGroupedError(responses[0]);
       this.accountingExportSummary = responses[1];
 
-      const queuedTasks: Sage300AccountingExport[] = responses[2].results.filter((accountingExport: Sage300AccountingExport) => accountingExport.status === AccountingExportStatus.ENQUEUED || accountingExport.status === AccountingExportStatus.IN_PROGRESS || AccountingExportStatus.EXPORT_QUEUED);
+      const queuedTasks: Sage300AccountingExport[] = responses[2].results.filter((accountingExport: Sage300AccountingExport) => accountingExport.status === AccountingExportStatus.ENQUEUED || accountingExport.status === AccountingExportStatus.IN_PROGRESS || accountingExport.status === AccountingExportStatus.EXPORT_QUEUED);
       this.failedExpenseGroupCount = responses[2].results.filter((accountingExport: Sage300AccountingExport) => accountingExport.status === AccountingExportStatus.FAILED || accountingExport.status === AccountingExportStatus.FATAL).length;
 
       if (queuedTasks.length) {

--- a/src/app/integrations/sage300/sage300-main/sage300-dashboard/sage300-dashboard.component.ts
+++ b/src/app/integrations/sage300/sage300-main/sage300-dashboard/sage300-dashboard.component.ts
@@ -104,7 +104,7 @@ export class Sage300DashboardComponent implements OnInit {
     forkJoin([
       this.getExportErrors$,
       this.getAccountingExportSummary$,
-      this.accountingExportService.getAccountingExports([AccountingExportStatus.ENQUEUED, AccountingExportStatus.IN_PROGRESS, AccountingExportStatus.EXPORT_QUEUED,AccountingExportStatus.FAILED, AccountingExportStatus.FATAL], [], 500, 0)
+      this.accountingExportService.getAccountingExports([AccountingExportStatus.ENQUEUED, AccountingExportStatus.IN_PROGRESS, AccountingExportStatus.EXPORT_QUEUED, AccountingExportStatus.FAILED, AccountingExportStatus.FATAL], [], 500, 0)
     ]).subscribe((responses) => {
       this.errors = DashboardModel.parseAPIResponseToGroupedError(responses[0]);
       this.accountingExportSummary = responses[1];

--- a/src/app/integrations/sage300/sage300-main/sage300-dashboard/sage300-dashboard.component.ts
+++ b/src/app/integrations/sage300/sage300-main/sage300-dashboard/sage300-dashboard.component.ts
@@ -53,7 +53,7 @@ export class Sage300DashboardComponent implements OnInit {
   ) { }
 
   private pollExportStatus(exportableAccountingExportIds: number[] = []): void {
-    interval(3000).pipe(
+    interval(20000).pipe(
       switchMap(() => from(this.accountingExportService.getAccountingExports([], exportableAccountingExportIds, 500, 0))),
       takeWhile((response: AccountingExportResponse) =>
         response.results.filter(task =>

--- a/src/app/integrations/sage300/sage300-main/sage300-dashboard/sage300-dashboard.component.ts
+++ b/src/app/integrations/sage300/sage300-main/sage300-dashboard/sage300-dashboard.component.ts
@@ -57,14 +57,14 @@ export class Sage300DashboardComponent implements OnInit {
       switchMap(() => from(this.accountingExportService.getAccountingExports([], exportableAccountingExportIds, 500, 0))),
       takeWhile((response: AccountingExportResponse) =>
         response.results.filter(task =>
-          (task.status === AccountingExportStatus.IN_PROGRESS || task.status === AccountingExportStatus.ENQUEUED) && exportableAccountingExportIds.includes(task.expense_group)
+          (task.status === AccountingExportStatus.IN_PROGRESS || task.status === AccountingExportStatus.ENQUEUED || AccountingExportStatus.EXPORT_QUEUED) && exportableAccountingExportIds.includes(task.expense_group)
         ).length > 0, true
       )
     ).subscribe((res: AccountingExportResponse) => {
       this.processedCount = res.results.filter(task => (task.status !== AccountingExportStatus.IN_PROGRESS && task.status !== AccountingExportStatus.ENQUEUED)).length;
       this.exportProgressPercentage = Math.round((this.processedCount / this.exportableAccountingExportIds.length) * 100);
 
-      if (res.results.filter(task => (task.status === AccountingExportStatus.IN_PROGRESS || task.status === AccountingExportStatus.ENQUEUED) && exportableAccountingExportIds.includes(task.expense_group)).length === 0) {
+      if (res.results.filter(task => (task.status === AccountingExportStatus.IN_PROGRESS || task.status === AccountingExportStatus.ENQUEUED || AccountingExportStatus.EXPORT_QUEUED) && exportableAccountingExportIds.includes(task.expense_group)).length === 0) {
         this.isLoading = true;
         forkJoin([
           this.getExportErrors$,

--- a/src/app/integrations/sage300/sage300-main/sage300-dashboard/sage300-dashboard.component.ts
+++ b/src/app/integrations/sage300/sage300-main/sage300-dashboard/sage300-dashboard.component.ts
@@ -61,7 +61,7 @@ export class Sage300DashboardComponent implements OnInit {
         ).length > 0, true
       )
     ).subscribe((res: AccountingExportResponse) => {
-      this.processedCount = res.results.filter(task => (task.status !== AccountingExportStatus.IN_PROGRESS && task.status !== AccountingExportStatus.ENQUEUED)).length;
+      this.processedCount = res.results.filter(task => (task.status !== AccountingExportStatus.IN_PROGRESS && task.status !== AccountingExportStatus.ENQUEUED && task.status !== AccountingExportStatus.EXPORT_QUEUED)).length;
       this.exportProgressPercentage = Math.round((this.processedCount / this.exportableAccountingExportIds.length) * 100);
 
       if (res.results.filter(task => (task.status === AccountingExportStatus.IN_PROGRESS || task.status === AccountingExportStatus.ENQUEUED || AccountingExportStatus.EXPORT_QUEUED) && exportableAccountingExportIds.includes(task.expense_group)).length === 0) {
@@ -104,12 +104,12 @@ export class Sage300DashboardComponent implements OnInit {
     forkJoin([
       this.getExportErrors$,
       this.getAccountingExportSummary$,
-      this.accountingExportService.getAccountingExports([AccountingExportStatus.ENQUEUED, AccountingExportStatus.IN_PROGRESS, AccountingExportStatus.FAILED, AccountingExportStatus.FATAL], [], 500, 0)
+      this.accountingExportService.getAccountingExports([AccountingExportStatus.ENQUEUED, AccountingExportStatus.IN_PROGRESS, AccountingExportStatus.EXPORT_QUEUED,AccountingExportStatus.FAILED, AccountingExportStatus.FATAL], [], 500, 0)
     ]).subscribe((responses) => {
       this.errors = DashboardModel.parseAPIResponseToGroupedError(responses[0]);
       this.accountingExportSummary = responses[1];
 
-      const queuedTasks: Sage300AccountingExport[] = responses[2].results.filter((accountingExport: Sage300AccountingExport) => accountingExport.status === AccountingExportStatus.ENQUEUED || accountingExport.status === AccountingExportStatus.IN_PROGRESS);
+      const queuedTasks: Sage300AccountingExport[] = responses[2].results.filter((accountingExport: Sage300AccountingExport) => accountingExport.status === AccountingExportStatus.ENQUEUED || accountingExport.status === AccountingExportStatus.IN_PROGRESS || AccountingExportStatus.EXPORT_QUEUED);
       this.failedExpenseGroupCount = responses[2].results.filter((accountingExport: Sage300AccountingExport) => accountingExport.status === AccountingExportStatus.FAILED || accountingExport.status === AccountingExportStatus.FATAL).length;
 
       if (queuedTasks.length) {


### PR DESCRIPTION
- Independent PR
- Minor Fix
- added a new polling state for sage300 EXPORT_QUEUED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new status indicator `EXPORT_QUEUED` for accounting export tasks to enhance tracking and management.

- **Enhancements**
  - Updated dashboard logic to include the new `EXPORT_QUEUED` status in the accounting export tasks count and processing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->