### PR TITLE
Add all fields in Import Settings

### DIFF
--- a/src/app/core/models/enum/enum.model.ts
+++ b/src/app/core/models/enum/enum.model.ts
@@ -591,4 +591,5 @@ export enum QBOField {
   CLASS = 'CLASS',
   DEPARTMENT = 'DEPARTMENT',
   CUSTOMER = 'CUSTOMER',
+  TAX_CODE = 'TAX_CODE'
 }

--- a/src/app/core/models/qbo/qbo-configuration/qbo-import-setting.model.ts
+++ b/src/app/core/models/qbo/qbo-configuration/qbo-import-setting.model.ts
@@ -7,10 +7,10 @@ import { QBOField } from "../../enum/enum.model"
 
 export type QBOImportSettingWorkspaceGeneralSetting = {
   import_categories: boolean,
-  // import_items: boolean,
-  // import_vendors_as_merchants: boolean,
-  // charts_of_accounts: string[],
-  // import_tax_codes: boolean
+  import_items: boolean,
+  import_vendors_as_merchants: boolean,
+  charts_of_accounts: string[],
+  import_tax_codes: boolean
 }
 
 export type QBOImportSettingGeneralMapping = {
@@ -19,7 +19,7 @@ export type QBOImportSettingGeneralMapping = {
 
 export type QBOImportSettingPost = {
   workspace_general_settings: QBOImportSettingWorkspaceGeneralSetting,
-  // general_mappings: QBOImportSettingGeneralMapping,
+  general_mappings: QBOImportSettingGeneralMapping,
   mapping_settings: ImportSettingMappingRow[] | []
 }
 
@@ -51,15 +51,28 @@ export class QBOImportSettingModel extends ImportSettingsModel {
     ];
   }
 
+  static getChartOfAccountTypesList(): string[] {
+    return [
+      'Expense', 'Other Expense', 'Fixed Asset', 'Cost of Goods Sold', 'Current Liability', 'Equity',
+      'Other Current Asset', 'Other Current Liability', 'Long Term Liability', 'Current Asset', 'Income', 'Other Income'
+    ];
+  }
+
   static mapAPIResponseToFormGroup(importSettings: QBOImportSettingGet | null): FormGroup {
     const expenseFieldsArray = importSettings?.mapping_settings ? this.constructFormArray(importSettings.mapping_settings, this.getQBOFields()) : [];
     return new FormGroup({
       importCategories: new FormControl(importSettings?.workspace_general_settings.import_categories ?? false),
-      expenseFields: new FormArray(expenseFieldsArray)
+      expenseFields: new FormArray(expenseFieldsArray),
+      chartOfAccountTypes: new FormControl(importSettings?.workspace_general_settings.charts_of_accounts ? importSettings.workspace_general_settings.charts_of_accounts : []),
+      importItems: new FormControl(importSettings?.workspace_general_settings.import_items ?? false),
+      taxCode: new FormControl(importSettings?.workspace_general_settings.import_tax_codes ?? false),
+      importVendorsAsMerchants: new FormControl(importSettings?.workspace_general_settings.import_vendors_as_merchants ?? false),
+      defaultTaxCode: new FormControl(importSettings?.general_mappings?.default_tax_code?.id ? importSettings.general_mappings.default_tax_code : null)
     });
   }
 
   static constructImportSettingPayload(importSettingsForm: FormGroup): QBOImportSettingPost {
+    const emptyDestinationAttribute = {id: null, name: null};
     const expenseFieldArray = importSettingsForm.value.expenseFields;
 
     // First filter out objects where import_to_fyle is false
@@ -75,11 +88,19 @@ export class QBOImportSettingModel extends ImportSettingsModel {
         source_placeholder: field.source_placeholder
       };
     });
+
     return {
       workspace_general_settings: {
         import_categories: importSettingsForm.get('importCategories')?.value,
+        import_items: importSettingsForm.get('importItems')?.value,
+        charts_of_accounts: importSettingsForm.get('chartOfAccountTypes')?.value,
+        import_tax_codes: importSettingsForm.get('taxCode')?.value,
+        import_vendors_as_merchants: importSettingsForm.get('importVendorsAsMerchants')?.value
       },
-      mapping_settings: mappingSettings
+      mapping_settings: mappingSettings,
+      general_mappings: {
+        default_tax_code: importSettingsForm.get('defaultTaxCode')?.value ? importSettingsForm.get('defaultTaxCode')?.value : emptyDestinationAttribute
+      },
     };
   }
 }

--- a/src/app/core/models/qbo/qbo-configuration/qbo-import-setting.model.ts
+++ b/src/app/core/models/qbo/qbo-configuration/qbo-import-setting.model.ts
@@ -1,9 +1,9 @@
-import { FormArray, FormControl, FormGroup } from "@angular/forms"
-import { ImportSettingMappingRow, ImportSettingsModel } from "../../common/import-settings.model"
-import { DefaultDestinationAttribute } from "../../db/destination-attribute.model"
-import { MappingSetting } from "../../db/mapping-setting.model"
-import { IntegrationField } from "../../db/mapping.model"
-import { QBOField } from "../../enum/enum.model"
+import { FormArray, FormControl, FormGroup } from "@angular/forms";
+import { ImportSettingMappingRow, ImportSettingsModel } from "../../common/import-settings.model";
+import { DefaultDestinationAttribute } from "../../db/destination-attribute.model";
+import { MappingSetting } from "../../db/mapping-setting.model";
+import { IntegrationField } from "../../db/mapping.model";
+import { QBOField } from "../../enum/enum.model";
 
 export type QBOImportSettingWorkspaceGeneralSetting = {
   import_categories: boolean,
@@ -100,7 +100,7 @@ export class QBOImportSettingModel extends ImportSettingsModel {
       mapping_settings: mappingSettings,
       general_mappings: {
         default_tax_code: importSettingsForm.get('defaultTaxCode')?.value ? importSettingsForm.get('defaultTaxCode')?.value : emptyDestinationAttribute
-      },
+      }
     };
   }
 }

--- a/src/app/core/services/qbo/qbo-configuration/qbo-import-settings.service.ts
+++ b/src/app/core/services/qbo/qbo-configuration/qbo-import-settings.service.ts
@@ -16,7 +16,7 @@ export class QboImportSettingsService {
 
   constructor(
     private apiService: ApiService,
-    private workspaceService: WorkspaceService,
+    private workspaceService: WorkspaceService
   ) { }
 
   @Cacheable({

--- a/src/app/core/services/qbo/qbo-configuration/qbo-import-settings.service.ts
+++ b/src/app/core/services/qbo/qbo-configuration/qbo-import-settings.service.ts
@@ -30,6 +30,6 @@ export class QboImportSettingsService {
     cacheBusterNotifier: qboImportSettingGetCache$
   })
   postImportSettings(importSettingsPayload: QBOImportSettingPost): Observable<QBOImportSettingGet> {
-    return this.apiService.put(`v2/workspaces/${this.workspaceId}/import_settings/`, importSettingsPayload);
+    return this.apiService.put(`/v2/workspaces/${this.workspaceId}/import_settings/`, importSettingsPayload);
   }
 }

--- a/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.html
+++ b/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.html
@@ -21,8 +21,66 @@
                         [isSectionHeader]="false"
                         [iconPath]="'arrow-tail-up-down'">
                     </app-configuration-toggle-field>
-                    <!-- TODO: get types, ITEMS, merchant import, tax group -->
+
+                    <div class="tw-p-24-px tw-pl-60-px tw-pt-0" *ngIf="importSettingForm.value.importCategories">
+                        <div class="tw-flex tw-justify-between tw-items-center">
+                            <h5 class="lg:tw-w-3/5 md:tw-w-1/2 tw-text-slightly-normal-text-color tw-text-14-px !tw-font-500">
+                                Select the accounts from QuickBooks to import as categories in Fyle
+                                <p class="tw-pt-8-px tw-text-faded-text-color">
+                                    By default expense will be selected. Open the dropdown to select more as per your requirements
+                                </p>
+                            </h5>
+                            <div class="p-field-checkbox tw-pl-34-px">
+                                <p-multiSelect [optionDisabled]="'Expense'" [placeholder]="'Select Chart of Accouts'" [options]="chartOfAccountTypesList" styleClass="tw-z-2" [formControlName]="'chartOfAccountTypes'">
+                                </p-multiSelect>
+                            </div>
+                        </div>
+                    </div>
                 </div>
+
+                <div class="tw-rounded-lg tw-border-separator tw-border tw-mt-24-px" *ngIf="workspaceGeneralSettings.reimbursable_expenses_object !== QBOReimbursableExpensesObject.JOURNAL_ENTRY && workspaceGeneralSettings.corporate_credit_card_expenses_object !== QBOCorporateCreditCardExpensesObject.JOURNAL_ENTRY">
+                    <app-configuration-toggle-field
+                      [form]="importSettingForm"
+                      [label]="'Import Products/Services from QuickBooks Online'"
+                      [subLabel]="'Products/services from QuickBooks Online will be imported as Categories in ' + brandingConfig.brandName +''"
+                      [formControllerName]="'importItems'"
+                      [iconPath]="'arrow-tail-up-down'">
+                    </app-configuration-toggle-field>
+                </div>
+
+                <div class="tw-rounded-lg tw-border-separator tw-border tw-mt-24-px" *ngIf="isTaxGroupSyncAllowed">
+                    <app-configuration-toggle-field
+                      [form]="importSettingForm"
+                      [label]="'Import Tax from QuickBooks Online'"
+                      [subLabel]="'The imported Tax codes from QuickBooks Online will be set as Tax group in ' + brandingConfig.brandName + '. This will be a selectable field while creating an expense.'"
+                      [formControllerName]="'taxCode'"
+                      [iconPath]="'arrow-tail-up-down'"
+                      [hasDependentFields]="true">
+                    </app-configuration-toggle-field>
+
+                    <app-configuration-select-field *ngIf="importSettingForm.value.taxCode"
+                        [form]="importSettingForm"
+                        [isFieldMandatory]="true"
+                        [mandatoryErrorListName]="'tax code'"
+                        [label]="'Select Default Tax Code'"
+                        [subLabel]="'If an expense from ' + brandingConfig.brandName + ' does not contain any tax group information during export, the default tax code will be used.'"
+                        [destinationAttributes]="taxCodes"
+                        [optionLabel]="'name'"
+                        [placeholder]="'Select tax code'"
+                        [formControllerName]="'defaultTaxCode'">
+                    </app-configuration-select-field>
+                  </div>
+
+                  <div class="tw-rounded-lg tw-border-separator tw-border tw-mt-24-px" *ngIf="isImportMerchantsAllowed">
+                    <app-configuration-toggle-field
+                        [form]="importSettingForm"
+                        [label]="'Import Vendors from QuickBooks Online'"
+                        [subLabel]="'Vendors from QuickBooks Online will be imported as merchants in ' + brandingConfig.brandName + ' and will be a selectable field while creating an expense.'"
+                        [formControllerName]="'importVendorsAsMerchants'"
+                        [iconPath]="'arrow-tail-up-down'">
+                    </app-configuration-toggle-field>
+                  </div>
+
                 <div>
                     <app-configuration-import-field
                         [form]="importSettingForm"

--- a/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.scss
+++ b/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.scss
@@ -1,0 +1,19 @@
+:host ::ng-deep .p-multiselect-label {
+    @apply tw-z-1 tw-px-12-px tw-py-8-px tw-w-270-px #{!important};
+}
+
+:host ::ng-deep .p-multiselect-panel .p-multiselect-header,:host ::ng-deep .p-multiselect-panel .p-multiselect-items {
+    @apply tw-p-0 #{!important};
+}
+
+:host ::ng-deep .p-multiselect-panel .p-multiselect-items .p-multiselect-item {
+    @apply tw-mb-0 #{!important};
+}
+
+:host ::ng-deep .p-checkbox {
+    @apply tw-pt-2-px #{!important};
+}
+
+:host ::ng-deep .p-multiselect-panel .p-multiselect-items .p-multiselect-item {
+    @apply tw-h-32-px tw-px-16-px tw-py-0 #{!important};
+}

--- a/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.ts
@@ -106,7 +106,7 @@ export class QboImportSettingsComponent implements OnInit {
     this.helperService.refreshQBODimensions().subscribe();
   }
 
-  private constructPayloadAndSave() {
+  save(): void {
     this.isSaveInProgress = true;
     const importSettingPayload = QBOImportSettingModel.constructImportSettingPayload(this.importSettingForm);
     this.importSettingService.postImportSettings(importSettingPayload).subscribe(() => {
@@ -121,11 +121,6 @@ export class QboImportSettingsComponent implements OnInit {
       this.isSaveInProgress = false;
       this.toastService.displayToastMessage(ToastSeverity.ERROR, 'Error saving import settings, please try again later');
     });
-  }
-
-  save(): void {
-    // TODO: add warning
-    this.constructPayloadAndSave();
   }
 
   saveFyleExpenseField(): void {

--- a/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.ts
@@ -4,12 +4,16 @@ import { Router } from '@angular/router';
 import { forkJoin } from 'rxjs';
 import { brandingConfig, brandingKbArticles } from 'src/app/branding/branding-config';
 import { ExpenseField, ImportSettingsModel } from 'src/app/core/models/common/import-settings.model';
+import { DefaultDestinationAttribute, DestinationAttribute } from 'src/app/core/models/db/destination-attribute.model';
 import { FyleField, IntegrationField } from 'src/app/core/models/db/mapping.model';
-import { AppName, ConfigurationCta, QBOOnboardingState, ToastSeverity } from 'src/app/core/models/enum/enum.model';
+import { AppName, ConfigurationCta, QBOCorporateCreditCardExpensesObject, QBOField, QBOOnboardingState, QBOReimbursableExpensesObject, ToastSeverity } from 'src/app/core/models/enum/enum.model';
+import { QBOWorkspaceGeneralSetting } from 'src/app/core/models/qbo/db/workspace-general-setting.model';
+import { QBOExportSettingModel } from 'src/app/core/models/qbo/qbo-configuration/qbo-export-setting.model';
 import { QBOImportSettingGet, QBOImportSettingModel } from 'src/app/core/models/qbo/qbo-configuration/qbo-import-setting.model';
 import { IntegrationsToastService } from 'src/app/core/services/common/integrations-toast.service';
 import { MappingService } from 'src/app/core/services/common/mapping.service';
 import { WorkspaceService } from 'src/app/core/services/common/workspace.service';
+import { QboConnectorService } from 'src/app/core/services/qbo/qbo-configuration/qbo-connector.service';
 import { QboImportSettingsService } from 'src/app/core/services/qbo/qbo-configuration/qbo-import-settings.service';
 import { QboHelperService } from 'src/app/core/services/qbo/qbo-core/qbo-helper.service';
 
@@ -60,10 +64,25 @@ export class QboImportSettingsComponent implements OnInit {
 
   customFieldOption: ExpenseField[] = ImportSettingsModel.getCustomFieldOption();
 
+  chartOfAccountTypesList: string[] = QBOImportSettingModel.getChartOfAccountTypesList();
+
+  workspaceGeneralSettings: QBOWorkspaceGeneralSetting;
+
+  QBOReimbursableExpensesObject = QBOReimbursableExpensesObject;
+
+  QBOCorporateCreditCardExpensesObject = QBOCorporateCreditCardExpensesObject;
+
+  isTaxGroupSyncAllowed: boolean;
+
+  taxCodes: DefaultDestinationAttribute[];
+
+  isImportMerchantsAllowed: boolean;
+
   constructor(
     private formBuilder: FormBuilder,
     private helperService: QboHelperService,
     private importSettingService: QboImportSettingsService,
+    private qboConnectorService: QboConnectorService,
     private mappingService: MappingService,
     private router: Router,
     private toastService: IntegrationsToastService,
@@ -140,7 +159,19 @@ export class QboImportSettingsComponent implements OnInit {
     this.showCustomFieldDialog = shouldShowDialog;
   }
 
+  private createTaxCodeWatcher(): void {
+    this.importSettingForm.controls.taxCode.valueChanges.subscribe((isTaxCodeEnabled) => {
+      if (isTaxCodeEnabled) {
+        this.importSettingForm.controls.defaultTaxCode.setValidators(Validators.required);
+      } else {
+        this.importSettingForm.controls.defaultTaxCode.clearValidators();
+        this.importSettingForm.controls.defaultTaxCode.setValue(null);
+      }
+    });
+  }
+
   private setupFormWatchers(): void {
+    this.createTaxCodeWatcher();
     const expenseFieldArray = this.importSettingForm.get('expenseFields') as FormArray;
     expenseFieldArray.controls.forEach((control:any) => {
       control.valueChanges.subscribe((value: { source_field: string; destination_field: string; }) => {
@@ -164,10 +195,21 @@ export class QboImportSettingsComponent implements OnInit {
     this.isOnboarding = this.router.url.includes('onboarding');
     forkJoin([
       this.importSettingService.getImportSettings(),
-      this.mappingService.getFyleFields('v1')
-    ]).subscribe(([importSettingsResponse, fyleFieldsResponse]) => {
+      this.mappingService.getFyleFields('v1'),
+      this.workspaceService.getWorkspaceGeneralSettings(),
+      this.qboConnectorService.getQBOCredentials(),
+      this.mappingService.getDestinationAttributes(QBOField.TAX_CODE, 'v1', 'qbo')
+    ]).subscribe(([importSettingsResponse, fyleFieldsResponse, workspaceGeneralSettings, qboCredentials, taxCodes]) => {
       this.qboFields = QBOImportSettingModel.getQBOFields();
       this.importSettings = importSettingsResponse;
+      this.workspaceGeneralSettings = workspaceGeneralSettings;
+      this.taxCodes = taxCodes.map((option: DestinationAttribute) => QBOExportSettingModel.formatGeneralMappingPayload(option));
+      this.isImportMerchantsAllowed = !workspaceGeneralSettings.auto_create_merchants_as_vendors;
+
+      if (qboCredentials && qboCredentials.country !== 'US') {
+        this.isTaxGroupSyncAllowed = true;
+      }
+
       this.importSettingForm = QBOImportSettingModel.mapAPIResponseToFormGroup(this.importSettings);
       this.fyleFields = fyleFieldsResponse;
       this.fyleFields.push({ attribute_type: 'custom_field', display_name: 'Create a Custom Field', is_dependent: true });

--- a/src/app/integrations/qbo/qbo-shared/qbo-shared.module.ts
+++ b/src/app/integrations/qbo/qbo-shared/qbo-shared.module.ts
@@ -3,6 +3,8 @@ import { CommonModule } from '@angular/common';
 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
+import { MultiSelectModule } from 'primeng/multiselect';
+
 import { QboEmployeeSettingsComponent } from './qbo-employee-settings/qbo-employee-settings.component';
 import { QboExportSettingsComponent } from './qbo-export-settings/qbo-export-settings.component';
 import { QboImportSettingsComponent } from './qbo-import-settings/qbo-import-settings.component';
@@ -22,7 +24,8 @@ import { SharedModule } from 'src/app/shared/shared.module';
     CommonModule,
     SharedModule,
     FormsModule,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    MultiSelectModule
   ],
   exports: [
     QboEmployeeSettingsComponent,

--- a/src/app/shared/components/configuration/configuration-toggle-field/configuration-toggle-field.component.html
+++ b/src/app/shared/components/configuration/configuration-toggle-field/configuration-toggle-field.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="form" class="tw-p-24-px tw-flex tw-justify-between tw-items-center">
+<div [formGroup]="form" class="tw-p-24-px tw-flex tw-justify-between tw-items-center" [ngClass]="{'tw-pb-0': hasDependentFields && form.value[formControllerName]}">
     <div class="tw-w-3/4 tw-flex tw-items-start">
       <div *ngIf="iconPath" [ngClass]="[iconPath ? 'tw-pr-16-px' : '']">
         <svg-icon-sprite [src]="iconPath" width="20px" height="20px" class="tw-text-mandatory-field-color"></svg-icon-sprite>

--- a/src/app/shared/components/configuration/configuration-toggle-field/configuration-toggle-field.component.ts
+++ b/src/app/shared/components/configuration/configuration-toggle-field/configuration-toggle-field.component.ts
@@ -23,6 +23,8 @@ export class ConfigurationToggleFieldComponent implements OnInit {
 
   @Input() iconPath: string;
 
+  @Input() hasDependentFields: boolean;
+
   constructor(
     public windowService: WindowService
   ) { }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -204,7 +204,7 @@ p {
 }
 
 .p-multiselect-panel .p-multiselect-items .p-multiselect-item {
-    @apply tw-h-54-px tw-px-16-px tw-py-8-px #{!important};
+    @apply tw-text-14-px tw-text-slightly-normal-text-color tw-h-54-px tw-px-16-px tw-py-8-px #{!important};
 }
 
 .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
@@ -216,7 +216,7 @@ p {
 }
 
 .p-multiselect-panel .p-multiselect-items .p-multiselect-item.p-highlight {
-    @apply tw-bg-disabled-bg-color tw-rounded-4-px #{!important};
+    @apply tw-text-14-px tw-text-slightly-normal-text-color tw-bg-disabled-bg-color tw-rounded-4-px #{!important};
 }
 
 .p-multiselect-panel .p-multiselect-items .p-multiselect-item:not(.p-highlight):not(.p-disabled):hover {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new settings for importing items, vendors, accounts, and tax codes from QuickBooks Online.
	- Added a new option to the settings for mapping tax codes.

- **Enhancements**
	- Updated QuickBooks Online import settings interface with additional configuration options.
	- Improved the user interface for multi-selection components.

- **Bug Fixes**
	- Corrected API endpoint in service layer to ensure proper data submission.

- **Style**
	- Adjusted styles for better visual appearance of the import settings component.

- **Refactor**
	- Enhanced code structure for import settings to support new features and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->