### PR TITLE
Import settings QBO fields to be dynamic, Fix post disconnect state

### DIFF
--- a/src/app/core/models/qbo/qbo-configuration/qbo-import-setting.model.ts
+++ b/src/app/core/models/qbo/qbo-configuration/qbo-import-setting.model.ts
@@ -34,23 +34,6 @@ export type QBOImportSettingGet = {
 
 
 export class QBOImportSettingModel extends ImportSettingsModel {
-  static getQBOFields(): IntegrationField[] {
-    return [
-      {
-        attribute_type: QBOField.CLASS,
-        display_name: 'Class'
-      },
-      {
-        attribute_type: QBOField.DEPARTMENT,
-        display_name: 'Department'
-      },
-      {
-        attribute_type: QBOField.CUSTOMER,
-        display_name: 'Customer'
-      }
-    ];
-  }
-
   static getChartOfAccountTypesList(): string[] {
     return [
       'Expense', 'Other Expense', 'Fixed Asset', 'Cost of Goods Sold', 'Current Liability', 'Equity',
@@ -58,8 +41,8 @@ export class QBOImportSettingModel extends ImportSettingsModel {
     ];
   }
 
-  static mapAPIResponseToFormGroup(importSettings: QBOImportSettingGet | null): FormGroup {
-    const expenseFieldsArray = importSettings?.mapping_settings ? this.constructFormArray(importSettings.mapping_settings, this.getQBOFields()) : [];
+  static mapAPIResponseToFormGroup(importSettings: QBOImportSettingGet | null, qboFields: IntegrationField[]): FormGroup {
+    const expenseFieldsArray = importSettings?.mapping_settings ? this.constructFormArray(importSettings.mapping_settings, qboFields) : [];
     return new FormGroup({
       importCategories: new FormControl(importSettings?.workspace_general_settings.import_categories ?? false),
       expenseFields: new FormArray(expenseFieldsArray),

--- a/src/app/core/services/qbo/qbo-configuration/qbo-import-settings.service.ts
+++ b/src/app/core/services/qbo/qbo-configuration/qbo-import-settings.service.ts
@@ -4,6 +4,7 @@ import { CacheBuster, Cacheable } from 'ts-cacheable';
 import { Observable, Subject } from 'rxjs';
 import { QBOImportSettingGet, QBOImportSettingPost } from 'src/app/core/models/qbo/qbo-configuration/qbo-import-setting.model';
 import { ApiService } from '../../common/api.service';
+import { IntegrationField } from 'src/app/core/models/db/mapping.model';
 
 const qboImportSettingGetCache$ = new Subject<void>();
 
@@ -31,5 +32,9 @@ export class QboImportSettingsService {
   })
   postImportSettings(importSettingsPayload: QBOImportSettingPost): Observable<QBOImportSettingGet> {
     return this.apiService.put(`/v2/workspaces/${this.workspaceId}/import_settings/`, importSettingsPayload);
+  }
+
+  getQBOFields(): Observable<IntegrationField[]> {
+    return this.apiService.get(`/workspaces/${this.workspaceId}/qbo/fields/`, {});
   }
 }

--- a/src/app/integrations/qbo/qbo-onboarding/qbo-clone-settings/qbo-clone-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-onboarding/qbo-clone-settings/qbo-clone-settings.component.ts
@@ -26,6 +26,7 @@ import { MappingService } from 'src/app/core/services/common/mapping.service';
 import { WorkspaceService } from 'src/app/core/services/common/workspace.service';
 import { QboConnectorService } from 'src/app/core/services/qbo/qbo-configuration/qbo-connector.service';
 import { QboExportSettingsService } from 'src/app/core/services/qbo/qbo-configuration/qbo-export-settings.service';
+import { QboImportSettingsService } from 'src/app/core/services/qbo/qbo-configuration/qbo-import-settings.service';
 
 @Component({
   selector: 'app-qbo-clone-settings',
@@ -167,6 +168,7 @@ export class QboCloneSettingsComponent implements OnInit {
     public helperService: HelperService,
     private mappingService: MappingService,
     private qboConnectorService: QboConnectorService,
+    private qboImportSettingsService: QboImportSettingsService,
     private router: Router,
     private toastService: IntegrationsToastService,
     private workspaceService: WorkspaceService
@@ -361,8 +363,9 @@ export class QboCloneSettingsComponent implements OnInit {
       this.mappingService.getGroupedDestinationAttributes(destinationAttributes, 'v1', 'qbo'),
       this.mappingService.getFyleFields('v1'),
       this.qboConnectorService.getQBOCredentials(),
-      this.configurationService.getAdditionalEmails()
-    ]).subscribe(([cloneSetting, destinationAttributes, fyleFieldsResponse, qboCredentials, adminEmails]) => {
+      this.configurationService.getAdditionalEmails(),
+      this.qboImportSettingsService.getQBOFields()
+    ]).subscribe(([cloneSetting, destinationAttributes, fyleFieldsResponse, qboCredentials, adminEmails, qboFields]) => {
       this.cloneSetting = cloneSetting;
 
       // Employee Settings
@@ -401,7 +404,7 @@ export class QboCloneSettingsComponent implements OnInit {
 
 
       // Import Settings
-      this.qboFields = QBOImportSettingModel.getQBOFields();
+      this.qboFields = qboFields;
       this.taxCodes = destinationAttributes.TAX_CODE.map((option: DestinationAttribute) => QBOExportSettingModel.formatGeneralMappingPayload(option));
       this.isImportMerchantsAllowed = !cloneSetting.advanced_configurations.workspace_general_settings.auto_create_merchants_as_vendors;
 
@@ -409,7 +412,7 @@ export class QboCloneSettingsComponent implements OnInit {
         this.isTaxGroupSyncAllowed = true;
       }
 
-      this.importSettingForm = QBOImportSettingModel.mapAPIResponseToFormGroup(cloneSetting.import_settings);
+      this.importSettingForm = QBOImportSettingModel.mapAPIResponseToFormGroup(cloneSetting.import_settings, this.qboFields);
       this.fyleFields = fyleFieldsResponse;
       this.fyleFields.push({ attribute_type: 'custom_field', display_name: 'Create a Custom Field', is_dependent: true });
       this.setupImportSettingFormWatcher();

--- a/src/app/integrations/qbo/qbo-onboarding/qbo-onboarding-connector/qbo-onboarding-connector.component.ts
+++ b/src/app/integrations/qbo/qbo-onboarding/qbo-onboarding-connector/qbo-onboarding-connector.component.ts
@@ -123,9 +123,7 @@ export class QboOnboardingConnectorComponent implements OnInit, OnDestroy {
   disconnectQbo(): void {
     this.isLoading = true;
     this.qboConnectorService.disconnectQBOConnection().subscribe(() => {
-      this.showDisconnectQBO = false;
-      this.qboCompanyName = null;
-      this.getSettings();
+      this.router.navigate(['/integrations/qbo/onboarding/landing']);
     });
   }
 

--- a/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.ts
@@ -199,9 +199,10 @@ export class QboImportSettingsComponent implements OnInit {
       this.mappingService.getFyleFields('v1'),
       this.workspaceService.getWorkspaceGeneralSettings(),
       this.qboConnectorService.getQBOCredentials(),
-      this.mappingService.getDestinationAttributes(QBOField.TAX_CODE, 'v1', 'qbo')
-    ]).subscribe(([importSettingsResponse, fyleFieldsResponse, workspaceGeneralSettings, qboCredentials, taxCodes]) => {
-      this.qboFields = QBOImportSettingModel.getQBOFields();
+      this.mappingService.getDestinationAttributes(QBOField.TAX_CODE, 'v1', 'qbo'),
+      this.importSettingService.getQBOFields()
+    ]).subscribe(([importSettingsResponse, fyleFieldsResponse, workspaceGeneralSettings, qboCredentials, taxCodes, qboFields]) => {
+      this.qboFields = qboFields;
       this.importSettings = importSettingsResponse;
       this.workspaceGeneralSettings = workspaceGeneralSettings;
       this.taxCodes = taxCodes.map((option: DestinationAttribute) => QBOExportSettingModel.formatGeneralMappingPayload(option));
@@ -211,7 +212,7 @@ export class QboImportSettingsComponent implements OnInit {
         this.isTaxGroupSyncAllowed = true;
       }
 
-      this.importSettingForm = QBOImportSettingModel.mapAPIResponseToFormGroup(this.importSettings);
+      this.importSettingForm = QBOImportSettingModel.mapAPIResponseToFormGroup(this.importSettings, this.qboFields);
       this.fyleFields = fyleFieldsResponse;
       this.fyleFields.push({ attribute_type: 'custom_field', display_name: 'Create a Custom Field', is_dependent: true });
       this.setupFormWatchers();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for fetching `IntegrationField` data, enhancing the QuickBooks Online (QBO) integration settings.
- **Enhancements**
	- Improved QBO onboarding experience by refining settings import functionality.
	- Streamlined the process for disconnecting QBO integration, redirecting users to a more relevant landing page post-disconnection.
- **Refactor**
	- Updated method signatures and logic in QBO import settings model to support enhanced data mapping and integration field retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->