### PR TITLE
Fix Usability Issues: Default Tax for Netsuite

### DIFF
--- a/src/app/branding/branding-config.ts
+++ b/src/app/branding/branding-config.ts
@@ -320,7 +320,8 @@ const content: ContentConfiguration = {
                     importSuppliersAsMerchantsLabel: 'Import Suppliers from Netsuite as Merchants',
                     importSuppliersAsMerchantsSubLabel: 'The Suppliers in Netsuite will be imported as Merchants in ' + brandingConfig.brandName + ' and will be a selectable field while creating an expense.',
                     notes: 'NOTE: To export billable expenses from Fyle, import Customers from Netsuite as Projects in Fyle.',
-                    toggleToastMessage: 'You have already mapped a tracking category from Netsuite to the Project field in '+ brandingConfig.brandName +'. Change the configured mapping to a new field to be able to import Customers in the Project field.'
+                    toggleToastMessage: 'You have already mapped a tracking category from Netsuite to the Project field in '+ brandingConfig.brandName +'. Change the configured mapping to a new field to be able to import Customers in the Project field.',
+                    importVendorsAsMerchantsLabel: 'Import Vendors from Netsuite'
                 },
                 advancedSettings: {
                     stepName: 'Advanced settings',
@@ -671,7 +672,8 @@ const content: ContentConfiguration = {
                     importSuppliersAsMerchantsLabel: 'Import Suppliers from Netsuite as Merchants',
                     importSuppliersAsMerchantsSubLabel: 'The Suppliers in Netsuite will be imported as Merchants in ' + brandingConfig.brandName + ' and will be a selectable field while creating an expense.',
                     notes: 'NOTE: To export billable expenses from Fyle, import Customers from Netsuite as Projects in Fyle.',
-                    toggleToastMessage: 'You have already mapped a tracking category from Netsuite to the Project field in '+ brandingConfig.brandName +'. Change the configured mapping to a new field to be able to import Customers in the Project field.'
+                    toggleToastMessage: 'You have already mapped a tracking category from Netsuite to the Project field in '+ brandingConfig.brandName +'. Change the configured mapping to a new field to be able to import Customers in the Project field.',
+                    importVendorsAsMerchantsLabel: 'Import vendors from Netsuite'
                 },
                 advancedSettings: {
                     stepName: 'Advanced settings',

--- a/src/app/core/models/branding/content-configuration.model.ts
+++ b/src/app/core/models/branding/content-configuration.model.ts
@@ -53,7 +53,8 @@ export type ContentConfiguration = {
                     importSuppliersAsMerchantsLabel: string;
                     importSuppliersAsMerchantsSubLabel: string;
                     notes: string,
-                    toggleToastMessage: string
+                    toggleToastMessage: string,
+                    importVendorsAsMerchantsLabel: string
                 },
                 advancedSettings: {
                     stepName: string;

--- a/src/app/core/models/enum/enum.model.ts
+++ b/src/app/core/models/enum/enum.model.ts
@@ -371,6 +371,11 @@ export enum XeroFyleField {
   BANK_ACCOUNT = 'BANK_ACCOUNT'
 }
 
+export enum NetsuiteFyleField {
+  PROJECT = 'PROJECT',
+  TAX_CODE = 'TAX_CODE'
+}
+
 export enum QBDAccountingExportsState {
   COMPLETE = 'COMPLETE',
   ENQUEUED = 'ENQUEUED',

--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.html
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.html
@@ -52,6 +52,18 @@
                       [formControllerName]="'taxCode'"
                       [iconPath]="'arrow-tail-down'">
                     </app-configuration-toggle-field>
+
+                    <app-configuration-select-field *ngIf="importSettingForm.value.taxCode"
+                        [form]="importSettingForm"
+                        [isFieldMandatory]="true"
+                        [mandatoryErrorListName]="'tax code'"
+                        [label]="brandingContent.defaultTaxCodeLabel"
+                        [subLabel]="'If an expense from ' + brandingConfig.brandName + ' does not contain any tax group information during export, the default tax code will be used.'"
+                        [destinationAttributes]="taxCodes"
+                        [optionLabel]="'value'"
+                        [placeholder]="'Select tax code'"
+                        [formControllerName]="'defaultTaxCode'">
+                    </app-configuration-select-field>
                   </div>
 
                   <div>

--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.ts
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.ts
@@ -74,7 +74,7 @@ export class NetsuiteImportSettingsComponent implements OnInit {
 
   readonly brandingFeatureConfig = brandingFeatureConfig;
 
-  readonly brandingContent = brandingContent.configuration.importSetting;
+  readonly brandingContent = brandingContent.netsuite.configuration.importSetting;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -186,7 +186,7 @@ export class NetsuiteImportSettingsComponent implements OnInit {
       this.netsuiteConnectorService.getSubsidiaryMapping(),
       this.importSettingService.getNetsuiteFields(),
       this.netsuiteExportSettingService.getExportSettings(),
-      this.mappingService.getDestinationAttributes(NetsuiteFyleField.TAX_CODE, 'v1', 'netsuite')
+      this.mappingService.getDestinationAttributes(NetsuiteFyleField.TAX_CODE, 'v2')
     ]).subscribe(([importSettingsResponse, fyleFieldsResponse, subsidiaryMapping, netsuiteFields, exportSetting, destinationAttribute]) => {
       this.importSettings = importSettingsResponse;
 

--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.ts
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.ts
@@ -186,7 +186,7 @@ export class NetsuiteImportSettingsComponent implements OnInit {
       this.netsuiteConnectorService.getSubsidiaryMapping(),
       this.importSettingService.getNetsuiteFields(),
       this.netsuiteExportSettingService.getExportSettings(),
-      this.mappingService.getDestinationAttributes(NetsuiteFyleField.TAX_CODE, 'v1', 'netsuite'),
+      this.mappingService.getDestinationAttributes(NetsuiteFyleField.TAX_CODE, 'v1', 'netsuite')
     ]).subscribe(([importSettingsResponse, fyleFieldsResponse, subsidiaryMapping, netsuiteFields, exportSetting, destinationAttribute]) => {
       this.importSettings = importSettingsResponse;
 

--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.ts
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.ts
@@ -4,9 +4,9 @@ import { Router } from '@angular/router';
 import { forkJoin } from 'rxjs';
 import { brandingConfig, brandingContent, brandingFeatureConfig, brandingKbArticles } from 'src/app/branding/branding-config';
 import { ExpenseField, ImportSettingsModel } from 'src/app/core/models/common/import-settings.model';
-import { DefaultDestinationAttribute } from 'src/app/core/models/db/destination-attribute.model';
+import { DefaultDestinationAttribute, DestinationAttribute } from 'src/app/core/models/db/destination-attribute.model';
 import { FyleField, IntegrationField } from 'src/app/core/models/db/mapping.model';
-import { AppName, ConfigurationCta, NetsuiteOnboardingState, ToastSeverity } from 'src/app/core/models/enum/enum.model';
+import { AppName, ConfigurationCta, NetsuiteFyleField, NetsuiteOnboardingState, ToastSeverity } from 'src/app/core/models/enum/enum.model';
 import { NetsuiteConfiguration } from 'src/app/core/models/netsuite/db/netsuite-workspace-general-settings.model';
 import { NetsuiteImportSettingModel } from 'src/app/core/models/netsuite/netsuite-configuration/netsuite-import-setting.model';
 import { IntegrationsToastService } from 'src/app/core/services/common/integrations-toast.service';
@@ -38,7 +38,7 @@ export class NetsuiteImportSettingsComponent implements OnInit {
 
   isTaxGroupSyncAllowed: boolean;
 
-  taxCodes: DefaultDestinationAttribute[];
+  taxCodes: DestinationAttribute[];
 
   isImportMerchantsAllowed: boolean;
 
@@ -185,8 +185,9 @@ export class NetsuiteImportSettingsComponent implements OnInit {
       this.mappingService.getFyleFields(),
       this.netsuiteConnectorService.getSubsidiaryMapping(),
       this.importSettingService.getNetsuiteFields(),
-      this.netsuiteExportSettingService.getExportSettings()
-    ]).subscribe(([importSettingsResponse, fyleFieldsResponse, subsidiaryMapping, netsuiteFields, exportSetting]) => {
+      this.netsuiteExportSettingService.getExportSettings(),
+      this.mappingService.getDestinationAttributes(NetsuiteFyleField.TAX_CODE, 'v1', 'netsuite'),
+    ]).subscribe(([importSettingsResponse, fyleFieldsResponse, subsidiaryMapping, netsuiteFields, exportSetting, destinationAttribute]) => {
       this.importSettings = importSettingsResponse;
 
       if (subsidiaryMapping && subsidiaryMapping.country_name !== 'US') {
@@ -198,8 +199,8 @@ export class NetsuiteImportSettingsComponent implements OnInit {
       }
 
       this.netsuiteFields = netsuiteFields;
-      this.importSettingForm = NetsuiteImportSettingModel.mapAPIResponseToFormGroup(this.importSettings, this.netsuiteFields);
-
+      this.importSettingForm = NetsuiteImportSettingModel.mapAPIResponseToFormGroup(this.importSettings, this.netsuiteFields, this.taxCodes);
+      this.taxCodes = destinationAttribute;
       this.fyleFields = fyleFieldsResponse;
       this.fyleFields.push({ attribute_type: 'custom_field', display_name: 'Create a Custom Field', is_dependent: true });
       this.setupFormWatchers();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration option to select a default tax code for expenses lacking tax group information during export.
	- Added a new enum `NetsuiteFyleField` with fields `PROJECT` and `TAX_CODE`.
	- Added `general_mappings` property to `NetsuiteImportSettingPost` and `NetsuiteImportSettingGet`.
	- Added a new `app-configuration-select-field` component in the HTML template for selecting a default tax code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->