### PR TITLE
xero CCC grouping options fix

### DIFF
--- a/src/app/core/models/xero/xero-configuration/xero-export-settings.model.ts
+++ b/src/app/core/models/xero/xero-configuration/xero-export-settings.model.ts
@@ -157,7 +157,7 @@ export class XeroExportSettingModel {
   static getCCCExpenseStateOptions(): SelectFormOption[] {
     return [
       {
-        label: 'Payment Processing',
+        label: 'Approved',
         value: XeroCCCExpenseState.APPROVED
       },
       {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the label for an option in the export settings from 'Payment Processing' to 'Approved'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->