### PR TITLE
docs: clarify local dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Please refer this link to find the [storybook](https://fylein.github.io/fyle-int
 Follow instructions mentioned in [Integrations Central](https://github.com/fylein/fyle-integrations-central/)
 
 ### Setup - 2
+* Run the `integrations-settings-api` service following instructions from [Integrations Central](https://github.com/fylein/fyle-integrations-central/)
+
+
 * Install dependencies
 
     ```bash


### PR DESCRIPTION
clarify that `integrations-settings-api` needs to be running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README.md with instructions for running the `integrations-settings-api` service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->