### PR TITLE
make the 'dependent imports' checkbox always checked

### DIFF
--- a/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.html
+++ b/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.html
@@ -103,7 +103,7 @@
             </div>
             <div class="tw-pt-26-px" *ngIf="expenseField.value.source_field==='PROJECT' && expenseField.value.import_to_fyle && expenseField.value.destination_field === dependentDestinationValue" [formGroup]="form">
                 <div class="tw-flex">
-                    <label class="container cursor-default tw-pl-24-px tw-text-14-px">Import Cost Code and Cost Type from {{appName}} as dependent fields
+                    <label [ngClass]="appName === AppName.SAGE300 ? 'cursor-default' : ''" class="container tw-pl-24-px tw-text-14-px">Import Cost Code and Cost Type from {{appName}} as dependent fields
                         <a *ngIf="appName === AppName.SAGE300" class="tw-text-link-primary tw-w-fit tw-inline-flex tw-items-center"
                             (click)="windowService.openInNewTab(dependantFieldSupportArticleLink)">
                             Read More
@@ -111,7 +111,7 @@
                                 class="tw-text-link-primary tw-pl-2-px tw-w-fit">
                             </app-svg-icon>
                         </a>
-                        <input type="checkbox" formControlName="isDependentImportEnabled" (click)="false">
+                        <input type="checkbox" formControlName="isDependentImportEnabled" (click)="appName === AppName.SAGE300 ? false : undefined">
                         <span class="checkmark"></span>
                     </label>
                 </div>

--- a/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.html
+++ b/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.html
@@ -103,19 +103,19 @@
             </div>
             <div class="tw-pt-26-px" *ngIf="expenseField.value.source_field==='PROJECT' && expenseField.value.import_to_fyle && expenseField.value.destination_field === dependentDestinationValue" [formGroup]="form">
                 <div class="tw-flex">
-                    <label class="container tw-pl-24-px tw-text-14-px">Import Cost Code and Cost Type from {{appName}} as dependent fields
-                        <a *ngIf="appName === AppName.SAGE300" class="tw-text-link-primary tw-w-fit tw-cursor-pointer tw-inline-flex tw-items-center"
+                    <label class="container cursor-default tw-pl-24-px tw-text-14-px">Import Cost Code and Cost Type from {{appName}} as dependent fields
+                        <a *ngIf="appName === AppName.SAGE300" class="tw-text-link-primary tw-w-fit tw-inline-flex tw-items-center"
                             (click)="windowService.openInNewTab(dependantFieldSupportArticleLink)">
                             Read More
                             <app-svg-icon *ngIf="brandingFeatureConfig.isIconsInsideButtonAllowed" [svgSource]="'open-in-new-tab'" [width]="'16px'" [height]="'16px'"
                                 class="tw-text-link-primary tw-pl-2-px tw-w-fit">
                             </app-svg-icon>
                         </a>
-                        <input type="checkbox" formControlName="isDependentImportEnabled">
+                        <input type="checkbox" formControlName="isDependentImportEnabled" (click)="false">
                         <span class="checkmark"></span>
                     </label>
                 </div>
-                <div *ngIf="form.value.isDependentImportEnabled && dependentImportFields">
+                <div *ngIf="dependentImportFields">
                     <div *ngFor="let dependentField of dependentImportFields; index as i" class="tw-flex tw-items-strat tw-pt-4" [ngClass]="[i ? 'tw-pl-20-px' : 'tw-pl-0-px']">
                         <div class="tw-pt-2-px">
                             <app-svg-icon [isTextColorAllowed]="true" [svgSource]="'line'" [width]="'21px'" [height]="'49px'" [styleClasses]="'tw-text-box-color'"></app-svg-icon>

--- a/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.html
+++ b/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.html
@@ -115,7 +115,7 @@
                         <span class="checkmark"></span>
                     </label>
                 </div>
-                <div *ngIf="dependentImportFields">
+                <div *ngIf="form.value.isDependentImportEnabled && dependentImportFields">
                     <div *ngFor="let dependentField of dependentImportFields; index as i" class="tw-flex tw-items-strat tw-pt-4" [ngClass]="[i ? 'tw-pl-20-px' : 'tw-pl-0-px']">
                         <div class="tw-pt-2-px">
                             <app-svg-icon [isTextColorAllowed]="true" [svgSource]="'line'" [width]="'21px'" [height]="'49px'" [styleClasses]="'tw-text-box-color'"></app-svg-icon>

--- a/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.scss
+++ b/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.scss
@@ -98,6 +98,10 @@
   @apply tw-relative tw-cursor-pointer tw-select-none tw-block #{!important};
 }
 
+.cursor-default {
+  @apply tw-cursor-default #{!important};
+}
+
 /* Hide the browser's default checkbox */
 .container input {
   @apply tw-absolute  tw-cursor-pointer tw-h-0 tw-w-0

--- a/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.ts
+++ b/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.ts
@@ -172,6 +172,7 @@ export class ConfigurationImportFieldComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.form.controls.isDependentImportEnabled.setValue(true);
   }
 
 }

--- a/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.ts
+++ b/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.ts
@@ -172,7 +172,9 @@ export class ConfigurationImportFieldComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.form.controls.isDependentImportEnabled.setValue(true);
+    if (this.appName === AppName.SAGE300) {
+      this.form.controls.isDependentImportEnabled.setValue(true);
+    }
   }
 
 }


### PR DESCRIPTION
- set `isDependentImportEnabled` to true on init
- make the checkbox uneditable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved user interaction by making the label non-clickable with a default cursor style.

- **Bug Fixes**
  - Ensured checkbox for dependent import is always enabled by default when the component initializes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->