### PR TITLE
netsuite new content change

### DIFF
--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-export-settings/netsuite-export-settings.component.html
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-export-settings/netsuite-export-settings.component.html
@@ -53,7 +53,7 @@
                                 [isFieldMandatory]="true"
                                 [mandatoryErrorListName]="'Employee Payables Account'"
                                 [label]="brandingContent.corporateCard.defaultDebitCardAccountLabel"
-                                [subLabel]="'Post all your company corporate card transactions to a default employee payables account.'"
+                                [subLabel]="'Post all your reimbursable expenses to a default employee payables account.'"
                                 [placeholder]="'Select a Employee Payables Account'"
                                 [formControllerName]="'bankAccount'">
                                 </app-configuration-select-field>
@@ -68,7 +68,7 @@
                                 [isFieldMandatory]="true"
                                 [mandatoryErrorListName]="'Vendor Payables Account'"
                                 [label]="brandingContent.corporateCard.accountsPayableLabel"
-                                [subLabel]="'Post all your company corporate card transactions to a default vendor payables account.'"
+                                [subLabel]="'Post all your reimbursable expenses to a default vendor payables account.'"
                                 [placeholder]="'Select Vendor Payable Account'"
                                 [formControllerName]="'accountsPayable'">
                                 </app-configuration-select-field>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated sub-labels in export settings to clarify that reimbursable expenses are posted to default accounts instead of company corporate card transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->