### PR TITLE
Intacct: Handle Split Expense

### DIFF
--- a/src/app/core/models/common/export-settings.model.ts
+++ b/src/app/core/models/common/export-settings.model.ts
@@ -1,5 +1,5 @@
 import { DefaultDestinationAttribute, DestinationAttribute } from "../db/destination-attribute.model";
-import { ExpenseGroupingFieldOption, ExportDateType, IntacctCorporateCreditCardExpensesObject, IntacctReimbursableExpensesObject } from "../enum/enum.model";
+import { ExpenseGroupingFieldOption, ExportDateType, IntacctCorporateCreditCardExpensesObject, IntacctReimbursableExpensesObject, SplitExpenseGrouping } from "../enum/enum.model";
 import { SelectFormOption } from "./select-form-option.model";
 
 export type ExportSettingValidatorRule = {
@@ -13,6 +13,19 @@ export type ExportModuleRule = {
 };
 
 export class ExportSettingModel {
+    static getSplitExpenseGroupingOptions(): SelectFormOption[] {
+      return [
+        {
+          label: 'Single Line Item',
+          value: SplitExpenseGrouping.SINGLE_LINE_ITEM
+        },
+        {
+          label: 'Multiple Line Item',
+          value: SplitExpenseGrouping.MULTIPLE_LINE_ITEM
+        }
+      ];
+    }
+
     static getExportGroup(exportGroups: string[] | null | undefined): string {
         if (exportGroups) {
             const exportGroup = exportGroups.find((exportGroup) => {

--- a/src/app/core/models/intacct/intacct-configuration/export-settings.model.ts
+++ b/src/app/core/models/intacct/intacct-configuration/export-settings.model.ts
@@ -39,7 +39,7 @@ export type ExpenseGroupSettingPost = {
 export interface IntacctExpenseGroupSettingPost extends ExpenseGroupSettingPost {
     split_expense_grouping: SplitExpenseGrouping;
   }
-  
+
 export interface IntacctExpenseGroupSettingGet extends IntacctExpenseGroupSettingPost {}
 
 export type ExportSettingGet = {

--- a/src/app/core/models/intacct/intacct-configuration/export-settings.model.ts
+++ b/src/app/core/models/intacct/intacct-configuration/export-settings.model.ts
@@ -1,5 +1,5 @@
 import { AbstractControl, FormGroup } from "@angular/forms";
-import { IntacctCorporateCreditCardExpensesObject, FyleField, ExpenseState, ExportDateType, IntacctReimbursableExpensesObject, CCCExpenseState, ExpenseGroupingFieldOption, IntacctExportSettingDestinationOptionKey } from "../../enum/enum.model";
+import { IntacctCorporateCreditCardExpensesObject, FyleField, ExpenseState, ExportDateType, IntacctReimbursableExpensesObject, CCCExpenseState, ExpenseGroupingFieldOption, IntacctExportSettingDestinationOptionKey, SplitExpenseGrouping } from "../../enum/enum.model";
 import { DefaultDestinationAttribute, DestinationAttribute } from "../../db/destination-attribute.model";
 import { IntacctDestinationAttribute } from "../db/destination-attribute.model";
 import { SelectFormOption } from "../../common/select-form-option.model";
@@ -36,16 +36,22 @@ export type ExpenseGroupSettingPost = {
     ccc_export_date_type: ExportDateType | null;
   };
 
+export interface IntacctExpenseGroupSettingPost extends ExpenseGroupSettingPost {
+    split_expense_grouping: SplitExpenseGrouping;
+  }
+  
+export interface IntacctExpenseGroupSettingGet extends IntacctExpenseGroupSettingPost {}
+
 export type ExportSettingGet = {
     configurations: ExportSettingConfiguration,
-    expense_group_settings: ExpenseGroupSettingPost,
+    expense_group_settings: IntacctExpenseGroupSettingGet,
     general_mappings: ExportSettingGeneralMapping,
     workspace_id: number
 }
 
 export type ExportSettingPost = {
     configurations: ExportSettingConfiguration,
-    expense_group_settings: ExpenseGroupSettingPost,
+    expense_group_settings: IntacctExpenseGroupSettingPost,
     general_mappings: ExportSettingGeneralMapping
   }
 
@@ -76,7 +82,8 @@ export type ExportSettingOptionSearch = {
                 reimbursable_expense_group_fields: exportSettingsForm.get('reimbursableExportGroup')?.value ? [exportSettingsForm.value.reimbursableExportGroup] : null,
                 reimbursable_export_date_type: exportSettingsForm.get('reimbursableExportDate')?.value ? exportSettingsForm.get('reimbursableExportDate')?.value : null,
                 corporate_credit_card_expense_group_fields: cccExportGroup,
-                ccc_export_date_type: getValueOrDefault(exportSettingsForm.get('cccExportDate')) === 'Spend Date' ? 'spent_at' : getValueOrDefault(exportSettingsForm.get('cccExportDate'))
+                ccc_export_date_type: getValueOrDefault(exportSettingsForm.get('cccExportDate')) === 'Spend Date' ? 'spent_at' : getValueOrDefault(exportSettingsForm.get('cccExportDate')),
+                split_expense_grouping: exportSettingsForm.get('splitExpenseGrouping')?.value ? exportSettingsForm.get('splitExpenseGrouping')?.value : SplitExpenseGrouping.MULTIPLE_LINE_ITEM
             },
             configurations: {
                 reimbursable_expenses_object: getValueOrDefault(exportSettingsForm.get('reimbursableExportType')),

--- a/src/app/core/models/qbo/qbo-configuration/qbo-export-setting.model.ts
+++ b/src/app/core/models/qbo/qbo-configuration/qbo-export-setting.model.ts
@@ -190,19 +190,6 @@ export class QBOExportSettingModel extends ExportSettingModel {
     ];
   }
 
-  static getSplitExpenseGroupingOptions(): SelectFormOption[] {
-    return [
-      {
-        label: 'Single Line Item',
-        value: SplitExpenseGrouping.SINGLE_LINE_ITEM
-      },
-      {
-        label: 'Multiple Line Item',
-        value: SplitExpenseGrouping.MULTIPLE_LINE_ITEM
-      }
-    ];
-  }
-
   static getMandatoryField(form: FormGroup, controllerName: string): boolean {
     switch (controllerName) {
       case 'bankAccount':

--- a/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.html
+++ b/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.html
@@ -260,6 +260,19 @@
                         [iconPath]="'calendar'"
                         [placeholder]="'Select date'"
                         [formControllerName]="'cccExportDate'"></app-configuration-select-field>
+                    
+                        <app-configuration-select-field *ngIf="brandingFeatureConfig.featureFlags.exportSettings.splitExpenseGrouping && 
+                        exportSettingsForm.value.cccExportType === IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION"
+                        [form]="exportSettingsForm"
+                        [isFieldMandatory]="true"
+                        [showClearIcon]="true"
+                        [mandatoryErrorListName]="'split expense grouping'"
+                        [label]="'How should the split expenses be grouped?'"
+                        [subLabel]="'Choose how expenses should be grouped for split expenses'"
+                        [options]="splitExpenseGroupingOptions"
+                        [iconPath]="'question-square-outline'"
+                        [placeholder]="'Select split expense grouping'"
+                        [formControllerName]="'splitExpenseGrouping'"></app-configuration-select-field>
                     </div>
                 </div>
             </div>

--- a/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { TitleCasePipe } from '@angular/common';
-import { AbstractControl, FormBuilder, FormGroup, ValidatorFn, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
 import { DomSanitizer } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { Observable, Subject, debounceTime, filter, forkJoin } from 'rxjs';
@@ -51,6 +51,8 @@ export class IntacctExportSettingsComponent implements OnInit {
   exportSettings: ExportSettingGet;
 
   customMessage: string;
+
+  splitExpenseGroupingOptions = ExportSettingModel.getSplitExpenseGroupingOptions();
 
   destinationOptions: ExportSettingDestinationAttributeOption = {
     [IntacctExportSettingDestinationOptionKey.ACCOUNT]: [],
@@ -476,7 +478,8 @@ export class IntacctExportSettingsComponent implements OnInit {
         creditCard: [findObjectById(this.destinationOptions.ACCOUNT, generalMappings?.default_credit_card.id)],
         chargeCard: [findObjectById(this.destinationOptions.CHARGE_CARD, generalMappings?.default_charge_card.id)],
         useMerchantInJournalLine: [brandingFeatureConfig.featureFlags.exportSettings.useMerchantInJournalLine ? (configurations?.use_merchant_in_journal_line ? configurations?.use_merchant_in_journal_line: false) : true],
-        searchOption: ['']
+        searchOption: [''],
+        splitExpenseGrouping: new FormControl(this.exportSettings?.expense_group_settings?.split_expense_grouping)
       });
 
       if (brandingConfig.brandId === 'co') {

--- a/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
@@ -84,7 +84,7 @@ export class QboExportSettingsComponent implements OnInit {
 
   EmployeeFieldMapping = EmployeeFieldMapping;
 
-  splitExpenseGroupingOptions = QBOExportSettingModel.getSplitExpenseGroupingOptions();
+  splitExpenseGroupingOptions = ExportSettingModel.getSplitExpenseGroupingOptions();
 
   previewImagePaths =[
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced "split expense grouping" options for Intacct export settings, allowing users to customize how split expenses are grouped.
  - Added a new selection field for split expenses in the Intacct export settings UI.

- **Improvements**
  - Unified the source of split expense grouping options across different export settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->