### PR TITLE
fix: unset `import_tax_codes` in clone settings payloads for US orgs

### DIFF
--- a/src/app/core/models/qbo/qbo-configuration/qbo-clone-setting.model.ts
+++ b/src/app/core/models/qbo/qbo-configuration/qbo-clone-setting.model.ts
@@ -21,11 +21,15 @@ export type QBOCloneSettingPost = {
 }
 
 export class QBOCloneSettingModel {
-    static constructPayload(employeeSettingForm: FormGroup, exportSettingForm: FormGroup, importSettingForm: FormGroup, advancedSettingForm: FormGroup): QBOCloneSettingPost {
+    static constructPayload(employeeSettingForm: FormGroup, exportSettingForm: FormGroup, importSettingForm: FormGroup, advancedSettingForm: FormGroup, isTaxGroupSyncAllowed: boolean): QBOCloneSettingPost {
         const employeeSettingPayload = QBOEmployeeSettingModel.constructPayload(employeeSettingForm);
         const exportSettingPayload = QBOExportSettingModel.constructPayload(exportSettingForm);
         const importSettingPayload = QBOImportSettingModel.constructPayload(importSettingForm);
         const advancedSettingPayload = QBOAdvancedSettingModel.constructPayload(advancedSettingForm);
+
+        if (!isTaxGroupSyncAllowed) {
+            importSettingPayload.workspace_general_settings.import_tax_codes = false;
+        }
 
         return {
             export_settings: exportSettingPayload,

--- a/src/app/core/models/xero/xero-configuration/clone-setting.model.ts
+++ b/src/app/core/models/xero/xero-configuration/clone-setting.model.ts
@@ -19,10 +19,14 @@ export type XeroCloneSettingPost = {
 }
 
 export class XeroCloneSettingModel {
-    static constructPayload(exportSettingForm: FormGroup, importSettingForm: FormGroup, advancedSettingForm: FormGroup): XeroCloneSettingPost {
+    static constructPayload(exportSettingForm: FormGroup, importSettingForm: FormGroup, advancedSettingForm: FormGroup, isTaxGroupSyncAllowed: boolean): XeroCloneSettingPost {
         const exportSettingPayload = XeroExportSettingModel.constructPayload(exportSettingForm);
         const importSettingPayload = XeroImportSettingModel.constructPayload(importSettingForm);
         const advancedSettingPayload = XeroAdvancedSettingModel.constructPayload(advancedSettingForm);
+
+        if (!isTaxGroupSyncAllowed) {
+            importSettingPayload.workspace_general_settings.import_tax_codes = false;
+        }
 
         return {
             export_settings: exportSettingPayload,

--- a/src/app/integrations/qbo/qbo-onboarding/qbo-clone-settings/qbo-clone-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-onboarding/qbo-clone-settings/qbo-clone-settings.component.ts
@@ -241,7 +241,7 @@ export class QboCloneSettingsComponent implements OnInit {
 
   save(): void {
     this.isSaveInProgress = true;
-    const cloneSettingPayload = QBOCloneSettingModel.constructPayload(this.employeeSettingForm, this.exportSettingForm, this.importSettingForm, this.advancedSettingForm);
+    const cloneSettingPayload = QBOCloneSettingModel.constructPayload(this.employeeSettingForm, this.exportSettingForm, this.importSettingForm, this.advancedSettingForm, this.isTaxGroupSyncAllowed);
 
     this.cloneSettingService.postCloneSettings(cloneSettingPayload).subscribe((response) => {
       this.isSaveInProgress = false;

--- a/src/app/integrations/xero/xero-onboarding/xero-clone-settings/xero-clone-settings.component.ts
+++ b/src/app/integrations/xero/xero-onboarding/xero-clone-settings/xero-clone-settings.component.ts
@@ -208,7 +208,7 @@ export class XeroCloneSettingsComponent implements OnInit {
 
   save(): void {
     this.isSaveInProgress = true;
-    const cloneSettingPayload = XeroCloneSettingModel.constructPayload(this.exportSettingForm, this.importSettingForm, this.advancedSettingForm);
+    const cloneSettingPayload = XeroCloneSettingModel.constructPayload(this.exportSettingForm, this.importSettingForm, this.advancedSettingForm, this.isTaxGroupSyncAllowed);
 
     this.cloneSettingService.postCloneSettings(cloneSettingPayload).subscribe((response) => {
       this.isSaveInProgress = false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to control tax code synchronization for QBO and Xero configurations. Users can now specify whether tax code groups should be synchronized during the onboarding setup.
  
- **Bug Fixes**
  - Ensured that tax code synchronization settings are correctly applied based on user selections in the QBO and Xero onboarding processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->