### PR TITLE
Intacct Split Expense Hidden

### DIFF
--- a/src/app/core/models/intacct/intacct-configuration/export-settings.model.ts
+++ b/src/app/core/models/intacct/intacct-configuration/export-settings.model.ts
@@ -44,14 +44,14 @@ export interface IntacctExpenseGroupSettingGet extends IntacctExpenseGroupSettin
 
 export type ExportSettingGet = {
     configurations: ExportSettingConfiguration,
-    expense_group_settings: IntacctExpenseGroupSettingGet,
+    expense_group_settings: ExpenseGroupSettingPost,
     general_mappings: ExportSettingGeneralMapping,
     workspace_id: number
 }
 
 export type ExportSettingPost = {
     configurations: ExportSettingConfiguration,
-    expense_group_settings: IntacctExpenseGroupSettingPost,
+    expense_group_settings: ExpenseGroupSettingPost,
     general_mappings: ExportSettingGeneralMapping
   }
 
@@ -82,8 +82,7 @@ export type ExportSettingOptionSearch = {
                 reimbursable_expense_group_fields: exportSettingsForm.get('reimbursableExportGroup')?.value ? [exportSettingsForm.value.reimbursableExportGroup] : null,
                 reimbursable_export_date_type: exportSettingsForm.get('reimbursableExportDate')?.value ? exportSettingsForm.get('reimbursableExportDate')?.value : null,
                 corporate_credit_card_expense_group_fields: cccExportGroup,
-                ccc_export_date_type: getValueOrDefault(exportSettingsForm.get('cccExportDate')) === 'Spend Date' ? 'spent_at' : getValueOrDefault(exportSettingsForm.get('cccExportDate')),
-                split_expense_grouping: exportSettingsForm.get('splitExpenseGrouping')?.value ? exportSettingsForm.get('splitExpenseGrouping')?.value : SplitExpenseGrouping.MULTIPLE_LINE_ITEM
+                ccc_export_date_type: getValueOrDefault(exportSettingsForm.get('cccExportDate')) === 'Spend Date' ? 'spent_at' : getValueOrDefault(exportSettingsForm.get('cccExportDate'))
             },
             configurations: {
                 reimbursable_expenses_object: getValueOrDefault(exportSettingsForm.get('reimbursableExportType')),

--- a/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.html
+++ b/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.html
@@ -261,8 +261,7 @@
                         [placeholder]="'Select date'"
                         [formControllerName]="'cccExportDate'"></app-configuration-select-field>
                     
-                        <app-configuration-select-field *ngIf="brandingFeatureConfig.featureFlags.exportSettings.splitExpenseGrouping && 
-                        exportSettingsForm.value.cccExportType === IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION"
+                        <app-configuration-select-field *ngIf="false"
                         [form]="exportSettingsForm"
                         [isFieldMandatory]="true"
                         [showClearIcon]="true"

--- a/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.html
+++ b/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.html
@@ -260,18 +260,6 @@
                         [iconPath]="'calendar'"
                         [placeholder]="'Select date'"
                         [formControllerName]="'cccExportDate'"></app-configuration-select-field>
-                    
-                        <app-configuration-select-field *ngIf="false"
-                        [form]="exportSettingsForm"
-                        [isFieldMandatory]="true"
-                        [showClearIcon]="true"
-                        [mandatoryErrorListName]="'split expense grouping'"
-                        [label]="'How should the split expenses be grouped?'"
-                        [subLabel]="'Choose how expenses should be grouped for split expenses'"
-                        [options]="splitExpenseGroupingOptions"
-                        [iconPath]="'question-square-outline'"
-                        [placeholder]="'Select split expense grouping'"
-                        [formControllerName]="'splitExpenseGrouping'"></app-configuration-select-field>
                     </div>
                 </div>
             </div>

--- a/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.ts
@@ -478,8 +478,7 @@ export class IntacctExportSettingsComponent implements OnInit {
         creditCard: [findObjectById(this.destinationOptions.ACCOUNT, generalMappings?.default_credit_card.id)],
         chargeCard: [findObjectById(this.destinationOptions.CHARGE_CARD, generalMappings?.default_charge_card.id)],
         useMerchantInJournalLine: [brandingFeatureConfig.featureFlags.exportSettings.useMerchantInJournalLine ? (configurations?.use_merchant_in_journal_line ? configurations?.use_merchant_in_journal_line: false) : true],
-        searchOption: [''],
-        splitExpenseGrouping: new FormControl(this.exportSettings?.expense_group_settings?.split_expense_grouping)
+        searchOption: ['']
       });
 
       if (brandingConfig.brandId === 'co') {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where conditional rendering logic in export settings was not functioning correctly. Removed the feature flag check.

- **Refactor**
  - Updated type definitions to standardize `ExpenseGroupSettingPost` usage across export settings models.
  - Removed redundant FormControl initialization for `splitExpenseGrouping` in export settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->