### PR TITLE
fix: update content in netsuite import settings

### DIFF
--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.ts
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.ts
@@ -45,6 +45,8 @@ export class NetsuiteImportSettingsComponent implements OnInit {
 
   isImportEmployeeAllowed: boolean;
 
+  isExpenseCategoryEnabled: boolean;
+
   netsuiteFields: IntegrationField[];
 
   fyleFields: FyleField[];
@@ -231,14 +233,14 @@ export class NetsuiteImportSettingsComponent implements OnInit {
   }
 
   getCategoryLabel(): string {
-    if (this.isImportEmployeeAllowed) {
+    if (this.isExpenseCategoryEnabled) {
       return brandingConfig.brandId !== 'co' ? 'Import the Expense Categories' : 'Import expense categories';
     }
     return  brandingConfig.brandId !== 'co' ? 'Import the Accounts' : 'Import accounts';
   }
 
   getCategorySubLabel(): string {
-    if (this.isImportEmployeeAllowed) {
+    if (this.isExpenseCategoryEnabled) {
       return 'Imported expense categories';
     }
     return 'Imported accounts';
@@ -260,7 +262,11 @@ export class NetsuiteImportSettingsComponent implements OnInit {
         this.isTaxGroupSyncAllowed = true;
       }
 
-      this.isImportEmployeeAllowed = (
+      if (workspaceGeneralSetting.employee_field_mapping === EmployeeFieldMapping .EMPLOYEE){
+        this.isImportEmployeeAllowed = true;
+      }
+
+      this.isExpenseCategoryEnabled = (
         workspaceGeneralSetting.reimbursable_expenses_object === NetsuiteReimbursableExpensesObject.EXPENSE_REPORT ||
         workspaceGeneralSetting.corporate_credit_card_expenses_object === NetsuiteReimbursableExpensesObject.EXPENSE_REPORT
       );

--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.ts
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-import-settings.component.ts
@@ -259,9 +259,12 @@ export class NetsuiteImportSettingsComponent implements OnInit {
       if (subsidiaryMapping && subsidiaryMapping.country_name !== '_unitedStates') {
         this.isTaxGroupSyncAllowed = true;
       }
-      if (workspaceGeneralSetting.employee_field_mapping === EmployeeFieldMapping .EMPLOYEE){
-        this.isImportEmployeeAllowed = true;
-      }
+
+      this.isImportEmployeeAllowed = (
+        workspaceGeneralSetting.reimbursable_expenses_object === NetsuiteReimbursableExpensesObject.EXPENSE_REPORT ||
+        workspaceGeneralSetting.corporate_credit_card_expenses_object === NetsuiteReimbursableExpensesObject.EXPENSE_REPORT
+      );
+
       if (workspaceGeneralSetting.reimbursable_expenses_object === NetsuiteReimbursableExpensesObject.BILL && (!workspaceGeneralSetting.corporate_credit_card_expenses_object || workspaceGeneralSetting.corporate_credit_card_expenses_object === 'BILL')) {
         this.isImportItemsAllowed = true;
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced import settings for employee data, broadening criteria for allowing imports based on new conditions related to reimbursable expenses and corporate credit card expenses.
	- Introduced a new boolean property, `isExpenseCategoryEnabled`, allowing for more granular control over the display of category labels in import settings.
- **Improvements**
	- Improved clarity in the control flow for import permissions, ensuring streamlined decision-making without affecting existing functionality for item imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->