### PR TITLE
fix: intacct remove expense_type from code prepend array

### DIFF
--- a/src/app/integrations/intacct/intacct-main/intacct-mapping/intacct-base-mapping/intacct-base-mapping.component.ts
+++ b/src/app/integrations/intacct/intacct-main/intacct-mapping/intacct-base-mapping/intacct-base-mapping.component.ts
@@ -38,7 +38,7 @@ export class IntacctBaseMappingComponent implements OnInit {
 
   cccExpenseObject: IntacctCorporateCreditCardExpensesObject | null;
 
-  acceptedCodeField: string[] = [SageIntacctField.ACCOUNT, SageIntacctField.DEPARTMENT, MappingSourceField.PROJECT, IntacctCategoryDestination.EXPENSE_TYPE];
+  acceptedCodeField: string[] = [SageIntacctField.ACCOUNT, SageIntacctField.DEPARTMENT, MappingSourceField.PROJECT];
 
   brandingConfig = brandingConfig;
 

--- a/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.ts
@@ -91,7 +91,7 @@ export class IntacctImportSettingsComponent implements OnInit {
 
   importCodeField: FormGroup[] = [];
 
-  acceptedImportCodeField: string[] = [SageIntacctField.ACCOUNT, SageIntacctField.DEPARTMENT, MappingSourceField.PROJECT, IntacctCategoryDestination.EXPENSE_TYPE];
+  acceptedImportCodeField: string[] = [SageIntacctField.ACCOUNT, SageIntacctField.DEPARTMENT, MappingSourceField.PROJECT];
 
   existingFields: string[] = ['employee id', 'organisation name', 'employee name', 'employee email', 'expense date', 'expense date', 'expense id', 'report id', 'employee id', 'department', 'state', 'reporter', 'report', 'purpose', 'vendor', 'category', 'category code', 'mileage distance', 'mileage unit', 'flight from city', 'flight to city', 'flight from date', 'flight to date', 'flight from class', 'flight to class', 'hotel checkin', 'hotel checkout', 'hotel location', 'hotel breakfast', 'currency', 'amount', 'foreign currency', 'foreign amount', 'tax', 'approver', 'project', 'billable', 'cost center', 'cost center code', 'approved on', 'reimbursable', 'receipts', 'paid date', 'expense created date'];
 
@@ -103,18 +103,6 @@ export class IntacctImportSettingsComponent implements OnInit {
 
   importCodeSelectorOptions: Record<string, { label: string; value: boolean; subLabel: string; }[]> = {
     "ACCOUNT": [
-      {
-        label: 'Import Codes + Names',
-        value: true,
-        subLabel: 'Example: 4567: Meals & Entertainment'
-      },
-      {
-        label: 'Import Names only',
-        value: false,
-        subLabel: 'Example: Meals & Entertainment'
-      }
-    ],
-    "EXPENSE_TYPE": [
       {
         label: 'Import Codes + Names',
         value: true,
@@ -182,7 +170,7 @@ export class IntacctImportSettingsComponent implements OnInit {
       sourceField = IntacctCategoryDestination.ACCOUNT;
     }
 
-    if (event.checked && this.acceptedImportCodeField.includes(sourceField)) {
+    if (event.checked && this.acceptedImportCodeField.includes(sourceField) && this.intacctImportCodeConfig[sourceField]) {
       // Create a new FormGroup
       const value = this.formBuilder.group({
         source_field: [sourceField],


### PR DESCRIPTION
### Description
remove the expense type from allowed dimension to code prepend

## Clickup
Please add link here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated import settings to streamline code handling by removing the `EXPENSE_TYPE` entry from accepted fields.
  
- **Bug Fixes**
	- Improved logic for creating new forms based on event checks, enhancing the accuracy of the import process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->