### PR TITLE
fix: page size change not updating localstorage

### DIFF
--- a/src/app/integrations/intacct/intacct-main/intacct-export-log/intacct-completed-export-log/intacct-completed-export-log.component.ts
+++ b/src/app/integrations/intacct/intacct-main/intacct-export-log/intacct-completed-export-log/intacct-completed-export-log.component.ts
@@ -96,10 +96,10 @@ export class IntacctCompletedExportLogComponent implements OnInit {
 
   pageSizeChanges(limit: number): void {
     this.isLoading = true;
-    this.limit = limit;
     this.currentPage = 1;
     this.selectedDateFilter = this.selectedDateFilter ? this.selectedDateFilter : null;
     this.getAccountingExports(limit, this.offset);
+    this.limit = limit;
   }
 
   pageChanges(offset: number): void {


### PR DESCRIPTION
### Description
Currently, the page size saved in localstorage does not update at all in intacct export logs. After this change, we store the new page size to localstorage on page size being updated

## Clickup
https://app.clickup.com/t/86cwh86c8