### PR TITLE
chore: Intacct connector page info box for fyle theme

### DIFF
--- a/src/app/branding/c1-contents-config.ts
+++ b/src/app/branding/c1-contents-config.ts
@@ -183,7 +183,8 @@ export const c1Contents = {
             connector: {
                 stepName: 'Connect to Sage Intacct',
                 subLabel: 'Provide your credentials to establish a secure connection between your Expense Management and Sage Intacct account. ',
-                locationSubLabel: 'Expenses will be posted to the Sage Intacct location entity selected here. You can\'t change the location entity once they\'re configured.'
+                locationSubLabel: 'Expenses will be posted to the Sage Intacct location entity selected here. You can\'t change the location entity once they\'re configured.',
+                connectorInfoLabel: 'Make sure you’re entering your integration credentials. These should be different than your Sage Intacct credentials.'
             },
             exportSetting: {
                 stepName: 'Export settings',

--- a/src/app/branding/fyle-contents-config.ts
+++ b/src/app/branding/fyle-contents-config.ts
@@ -183,7 +183,8 @@ export const fyleContents = {
             connector: {
                 stepName: 'Connect to Sage Intacct',
                 locationSubLabel: 'Expenses will be posted to the Sage Intacct Location entity selected here. Once configured, you can not change ' + brandingConfig.brandName + ' Organization or Location Entity.',
-                subLabel: 'To connect your ' + brandingConfig.brandName + ' and Sage Intacct account, follow the detailed instructions provided in the article to generate the credentials and establish a secure connection.'
+                subLabel: 'To connect your ' + brandingConfig.brandName + ' and Sage Intacct account, follow the detailed instructions provided in the article to generate the credentials and establish a secure connection.',
+                connectorInfoLabel: 'Please use the integration credentials you received via email. These are different from the ones you use to login to your Sage Intacct account.'
             },
             exportSetting: {
                 stepName: 'Export Settings',

--- a/src/app/core/models/branding/content-configuration.model.ts
+++ b/src/app/core/models/branding/content-configuration.model.ts
@@ -179,7 +179,8 @@ export type ContentConfiguration = {
                 connector: {
                     stepName: string;
                     subLabel: string;
-                    locationSubLabel: string
+                    locationSubLabel: string;
+                    connectorInfoLabel: string;
                 },
                 exportSetting: {
                     stepName: string;

--- a/src/app/shared/components/si/core/intacct-connector/intacct-connector.component.html
+++ b/src/app/shared/components/si/core/intacct-connector/intacct-connector.component.html
@@ -36,12 +36,12 @@
              </div>
              <div *ngIf="brandingConfig.brandId === 'co'" class="tw-w-400-px tw-py-8-px tw-px-16-px tw-rounded-6-px tw-bg-bg-tertiary-lighter tw-border tw-border-separator">
               <p class="tw-text-14-px tw-text-text-primary">
-                  Make sure you’re entering your integration credentials. These should be different than your Sage Intacct credentials.
+                  {{brandingContent.intacct.configuration.connector.connectorInfoLabel}}
               </p>
             </div>
             <div *ngIf="brandingConfig.brandId !== 'co'" class="tw-w-400-px">
               <app-configuration-info-label
-                [infoText]="'Make sure you’re entering your integration credentials. These should be different than your Sage Intacct credentials.'">
+                [infoText]="brandingContent.intacct.configuration.connector.connectorInfoLabel">
               </app-configuration-info-label>
             </div>
            </div>

--- a/src/app/shared/components/si/core/intacct-connector/intacct-connector.component.html
+++ b/src/app/shared/components/si/core/intacct-connector/intacct-connector.component.html
@@ -34,8 +34,8 @@
                   Incorrect {{brandingContent.intacct.common.password}}. Enter correct {{brandingContent.intacct.common.password}}.
                 </div>
              </div>
-             <div *ngIf="brandingConfig.brandId === 'co'" class="tw-w-400-px tw-py-8-px tw-px-16-px tw-bg-bg-tertiary-lighter tw-border tw-border-separator tw-rounded-6-px">
-              <p class="tw-text-14-px tw-text-text-primary">
+             <div class="tw-w-400-px tw-py-8-px tw-px-16-px tw-rounded-6-px" [ngClass]="{'tw-bg-bg-tertiary-lighter tw-border tw-border-separator' : brandingConfig.brandId === 'co', 'tw-bg-info-section' : brandingConfig.brandId !== 'co'}">
+              <p class="tw-text-14-px" [ngClass]="{'tw-text-text-primary' : brandingConfig.brandId === 'co', 'tw-text-faded-text-color' : brandingConfig.brandId !== 'co'}">
                   Make sure you’re entering your integration credentials. These should be different than your Sage Intacct credentials.
               </p>
             </div>

--- a/src/app/shared/components/si/core/intacct-connector/intacct-connector.component.html
+++ b/src/app/shared/components/si/core/intacct-connector/intacct-connector.component.html
@@ -34,10 +34,15 @@
                   Incorrect {{brandingContent.intacct.common.password}}. Enter correct {{brandingContent.intacct.common.password}}.
                 </div>
              </div>
-             <div class="tw-w-400-px tw-py-8-px tw-px-16-px tw-rounded-6-px" [ngClass]="{'tw-bg-bg-tertiary-lighter tw-border tw-border-separator' : brandingConfig.brandId === 'co', 'tw-bg-info-section' : brandingConfig.brandId !== 'co'}">
-              <p class="tw-text-14-px" [ngClass]="{'tw-text-text-primary' : brandingConfig.brandId === 'co', 'tw-text-faded-text-color' : brandingConfig.brandId !== 'co'}">
+             <div *ngIf="brandingConfig.brandId === 'co'" class="tw-w-400-px tw-py-8-px tw-px-16-px tw-rounded-6-px tw-bg-bg-tertiary-lighter tw-border tw-border-separator">
+              <p class="tw-text-14-px tw-text-text-primary">
                   Make sure you’re entering your integration credentials. These should be different than your Sage Intacct credentials.
               </p>
+            </div>
+            <div *ngIf="brandingConfig.brandId !== 'co'" class="tw-w-400-px">
+              <app-configuration-info-label
+                [infoText]="'Make sure you’re entering your integration credentials. These should be different than your Sage Intacct credentials.'">
+              </app-configuration-info-label>
             </div>
            </div>
          </div>


### PR DESCRIPTION
### Description
Adding a Info box for the Intacct connector page similar to the C1 env

## Clickup
https://app.clickup.com/t/86cwnfg30

<img width="445" alt="Screenshot 2024-10-01 at 2 41 37 PM" src="https://github.com/user-attachments/assets/d7f22a4b-8b14-4e0d-a77d-60f41eeda5e2">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced integration configuration for accounting systems, including detailed labels and instructions for NetSuite, Xero, Sage Intacct, and QuickBooks Online.
	- Improved user interface for the Sage Intacct connection form with tailored messages and visual cues based on branding configuration.
	- Expanded customization options for corporate card expenses, including default values and scheduling automatic exports.

- **Bug Fixes**
	- Improved validation messages for input fields to enhance user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->