### PR TITLE
test: fix failing tests due to outdated router spies

### DIFF
--- a/src/app/integrations/qbo/qbo.component.spec.ts
+++ b/src/app/integrations/qbo/qbo.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { of } from 'rxjs';
 import { QboComponent } from './qbo.component';
 import { HelperService } from 'src/app/core/services/common/helper.service';
@@ -10,22 +10,23 @@ import { WorkspaceService } from 'src/app/core/services/common/workspace.service
 import { QboHelperService } from 'src/app/core/services/qbo/qbo-core/qbo-helper.service';
 import { QBOOnboardingState, AppUrl } from 'src/app/core/models/enum/enum.model';
 import { mockUser, mockWorkspace, testOnboardingState } from './qbo.fixture';
+import { SharedModule } from 'src/app/shared/shared.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('QboComponent', () => {
   let component: QboComponent;
   let fixture: ComponentFixture<QboComponent>;
   let helperServiceSpy: jasmine.SpyObj<HelperService>;
   let qboHelperServiceSpy: jasmine.SpyObj<QboHelperService>;
-  let routerSpy: jasmine.SpyObj<Router>;
   let storageServiceSpy: jasmine.SpyObj<StorageService>;
   let userServiceSpy: jasmine.SpyObj<IntegrationsUserService>;
   let workspaceServiceSpy: jasmine.SpyObj<WorkspaceService>;
   let windowServiceMock: Partial<WindowService>;
+  let router: Router;
 
   beforeEach(async () => {
     const helperSpy = jasmine.createSpyObj('HelperService', ['setBaseApiURL']);
     const qboHelperSpy = jasmine.createSpyObj('QboHelperService', ['syncFyleDimensions', 'syncQBODimensions']);
-    const routerSpyObj = jasmine.createSpyObj('Router', ['navigateByUrl']);
     const storageSpy = jasmine.createSpyObj('StorageService', ['set']);
     const userSpy = jasmine.createSpyObj('IntegrationsUserService', ['getUserProfile']);
     const workspaceSpy = jasmine.createSpyObj('WorkspaceService', ['getWorkspace', 'postWorkspace']);
@@ -46,24 +47,26 @@ describe('QboComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      declarations: [ QboComponent ],
+      declarations: [QboComponent],
+      imports: [SharedModule, HttpClientTestingModule],
       providers: [
         { provide: HelperService, useValue: helperSpy },
         { provide: QboHelperService, useValue: qboHelperSpy },
-        { provide: Router, useValue: routerSpyObj },
         { provide: StorageService, useValue: storageSpy },
         { provide: IntegrationsUserService, useValue: userSpy },
         { provide: WorkspaceService, useValue: workspaceSpy },
-        { provide: WindowService, useValue: windowServiceMock }
+        { provide: WindowService, useValue: windowServiceMock },
+        provideRouter([])
       ]
     }).compileComponents();
 
     helperServiceSpy = TestBed.inject(HelperService) as jasmine.SpyObj<HelperService>;
     qboHelperServiceSpy = TestBed.inject(QboHelperService) as jasmine.SpyObj<QboHelperService>;
-    routerSpy = TestBed.inject(Router) as jasmine.SpyObj<Router>;
     storageServiceSpy = TestBed.inject(StorageService) as jasmine.SpyObj<StorageService>;
     userServiceSpy = TestBed.inject(IntegrationsUserService) as jasmine.SpyObj<IntegrationsUserService>;
     workspaceServiceSpy = TestBed.inject(WorkspaceService) as jasmine.SpyObj<WorkspaceService>;
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigateByUrl');
 
     userServiceSpy.getUserProfile.and.returnValue(mockUser);
     qboHelperServiceSpy.syncFyleDimensions.and.returnValue(of(null));
@@ -91,7 +94,7 @@ describe('QboComponent', () => {
     expect(storageServiceSpy.set).toHaveBeenCalledWith('onboarding-state', QBOOnboardingState.CONNECTION);
     expect(qboHelperServiceSpy.syncFyleDimensions).toHaveBeenCalled();
     expect(qboHelperServiceSpy.syncQBODimensions).toHaveBeenCalled();
-    expect(routerSpy.navigateByUrl).toHaveBeenCalledWith('/integrations/qbo/onboarding/landing');
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/integrations/qbo/onboarding/landing');
   }));
 
   it('should create a new workspace if none exists', fakeAsync(() => {
@@ -104,12 +107,11 @@ describe('QboComponent', () => {
     expect(workspaceServiceSpy.postWorkspace).toHaveBeenCalled();
     expect(storageServiceSpy.set).toHaveBeenCalledWith('workspaceId', '1');
     expect(storageServiceSpy.set).toHaveBeenCalledWith('onboarding-state', QBOOnboardingState.CONNECTION);
-    expect(routerSpy.navigateByUrl).toHaveBeenCalledWith('/integrations/qbo/onboarding/landing');
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/integrations/qbo/onboarding/landing');
   }));
 
   it('should navigate to correct route based on onboarding state', fakeAsync(() => {
-    testOnboardingState.forEach(({ state, route }) => {
-      routerSpy.navigateByUrl.calls.reset();
+    testOnboardingState.forEach(({ state }) => {
       const testWorkspace = { ...mockWorkspace, onboarding_state: state };
       workspaceServiceSpy.getWorkspace.and.returnValue(of([testWorkspace]));
 
@@ -125,6 +127,6 @@ describe('QboComponent', () => {
     fixture.detectChanges();
     tick();
 
-    expect(routerSpy.navigateByUrl).toHaveBeenCalled();
+    expect(router.navigateByUrl).toHaveBeenCalled();
   }));
 });


### PR DESCRIPTION
### Description
We were using deprecated ways to mock and test routers in `IntacctComponent` and `QboComponent` unit tests, which caused tests to fail. All tests are passing now

## Clickup
https://app.clickup.com/t/86cwabccw
https://app.clickup.com/t/86cwh86bz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved test reliability for the `IntacctComponent` and `QboComponent` by streamlining router usage in tests.
  
- **Tests**
	- Enhanced testing environment with updated imports for `SharedModule` and `HttpClientTestingModule`.
	- Adjusted test cases to directly reference the router instance, ensuring accurate navigation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->