### PR TITLE
test: intacct c1 import settings watchers

### DIFF
--- a/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.spec.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.spec.ts
@@ -1,5 +1,6 @@
+/* eslint-disable dot-notation */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormArray, FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { FormArray, FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { provideRouter, Router, RouterModule } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { IntacctC1ImportSettingsComponent } from './intacct-c1-import-settings.component';
@@ -21,8 +22,7 @@ import {
   sageIntacctFieldsSortedByPriorityForC1,
   importSettingsWithProjectMapping,
   expenseFieldsExpectedForC1,
-  costCodeFieldValue,
-  costTypeFieldValue
+  blankMapping
 } from '../../intacct.fixture';
 import { IntacctConfiguration } from 'src/app/core/models/db/configuration.model';
 import { ImportSettingGet, ImportSettingPost, ImportSettings } from 'src/app/core/models/intacct/intacct-configuration/import-settings.model';
@@ -222,6 +222,108 @@ describe('IntacctC1ImportSettingsComponent', () => {
       expect(importSettingService.postImportSettings).toHaveBeenCalled();
       expect(toastService.displayToastMessage).toHaveBeenCalledWith(ToastSeverity.ERROR, 'Error saving import settings, please try again later');
       expect(component.saveInProgress).toBeFalse();
+    });
+  });
+
+  describe('Watchers', () => {
+    let isDependentImportEnabledValueChangeSpy: jasmine.Spy;
+    let blankExpenseField: FormGroup;
+    let costCodesValueChangeSubscription: jasmine.Spy;
+    let costTypesValueChangeSubscription: jasmine.Spy;
+
+    beforeEach(() => {
+      component.ngOnInit();
+
+      isDependentImportEnabledValueChangeSpy = spyOn(component.importSettingsForm.controls.isDependentImportEnabled.valueChanges, 'subscribe').and.callThrough();
+      blankExpenseField = component['createFormGroup'](blankMapping);
+      costCodesValueChangeSubscription = spyOn(component.importSettingsForm.controls.costCodes.valueChanges, 'subscribe');
+      costTypesValueChangeSubscription = spyOn(component.importSettingsForm.controls.costTypes.valueChanges, 'subscribe');
+
+      spyOn(blankExpenseField.valueChanges, 'subscribe').and.callThrough();
+    });
+
+    describe('dependentFieldWatchers', () => {
+      beforeEach(() => {
+        component['dependentFieldWatchers']();
+      });
+
+      it('should setup watchers for dependent fields', () => {
+        expect(component.importSettingsForm.controls.isDependentImportEnabled.valueChanges.subscribe).toHaveBeenCalled();
+        expect(component.importSettingsForm.controls.costCodes.valueChanges.subscribe).toHaveBeenCalled();
+        expect(component.importSettingsForm.controls.costTypes.valueChanges.subscribe).toHaveBeenCalled();
+      });
+
+      it('should handle isDependentImportEnabled being set', () => {
+        component.importSettingsForm.get('isDependentImportEnabled')?.setValue(true);
+
+        expect(helperService.enableFormField).toHaveBeenCalledWith(component.importSettingsForm, 'costCodes');
+        expect(helperService.enableFormField).toHaveBeenCalledWith(component.importSettingsForm, 'costTypes');
+        expect(helperService.markControllerAsRequired).toHaveBeenCalledWith(component.importSettingsForm, 'costCodes');
+        expect(helperService.markControllerAsRequired).toHaveBeenCalledWith(component.importSettingsForm, 'costTypes');
+        expect(component.dependentImportFields[0].isDisabled).toBeFalse();
+        expect(component.dependentImportFields[1].isDisabled).toBeFalse();
+      });
+
+      it('should handle isDependentImportEnabled being unset', () => {
+        component.importSettingsForm.get('isDependentImportEnabled')?.setValue(false);
+
+        expect(helperService.disableFormField).toHaveBeenCalledWith(component.importSettingsForm, 'costCodes');
+        expect(helperService.disableFormField).toHaveBeenCalledWith(component.importSettingsForm, 'costTypes');
+        expect(helperService.clearValidatorAndResetValue).toHaveBeenCalledWith(component.importSettingsForm, 'costCodes');
+        expect(helperService.clearValidatorAndResetValue).toHaveBeenCalledWith(component.importSettingsForm, 'costTypes');
+        expect(component.dependentImportFields[0].isDisabled).toBeTrue();
+        expect(component.dependentImportFields[1].isDisabled).toBeTrue();
+      });
+    });
+
+    describe('dependentCostFieldsWatchers', () => {
+      beforeEach(() => {
+        component['dependentCostFieldsWatchers']('costCodes');
+        component['dependentCostFieldsWatchers']('costTypes');
+      });
+
+      it('should setup watchers for cost fields', () => {
+        expect(component.importSettingsForm.controls.costCodes.valueChanges.subscribe).toHaveBeenCalled();
+        expect(component.importSettingsForm.controls.costTypes.valueChanges.subscribe).toHaveBeenCalled();
+      });
+
+      it('should handle custom field selection for costCodes', () => {
+        component.importSettingsForm.controls.costCodes.setValue({ attribute_type: 'custom_field' });
+
+        expect(component.customFieldType).toBe('costCodes');
+        expect(component.customFieldControl).toBe(component.importSettingsForm.controls.costCodes);
+      });
+
+      it('should handle custom field selection for costTypes', () => {
+        component.importSettingsForm.controls.costTypes.setValue({ attribute_type: 'custom_field' });
+
+        expect(component.customFieldType).toBe('costTypes');
+        expect(component.customFieldControl).toBe(component.importSettingsForm.controls.costTypes);
+      });
+
+      it('should handle non-custom field selection', () => {
+        component.importSettingsForm.controls.costCodes.setValue({ attribute_type: 'some_field' });
+        expect(component.dependentImportFields[0].isDisabled).toBeTrue();
+      });
+    });
+
+    describe('importSettingWatcher', () => {
+      beforeEach(() => {
+        (component.importSettingsForm.get('expenseFields') as FormArray).controls = [blankExpenseField];
+        component['importSettingWatcher']();
+      });
+
+      it('should setup watchers for expense fields', () => {
+        expect(blankExpenseField.valueChanges.subscribe).toHaveBeenCalled();
+      });
+
+      it('should handle custom field selection in expense fields', () => {
+        spyOn(blankExpenseField, 'patchValue').and.callThrough();
+        blankExpenseField.patchValue({ source_field: 'custom_field' });
+
+        expect(component.customFieldControl).toBe(blankExpenseField);
+        expect(blankExpenseField.patchValue).toHaveBeenCalledWith(blankMapping);
+      });
     });
   });
 });

--- a/src/app/integrations/intacct/intacct.fixture.ts
+++ b/src/app/integrations/intacct/intacct.fixture.ts
@@ -9,7 +9,7 @@ import { ExpenseGroup, ExpenseGroupDescription, ExpenseGroupResponse } from 'src
 import { Paginator } from 'src/app/core/models/misc/paginator.model';
 import { SkipExportLogResponse } from "src/app/core/models/intacct/db/expense-group.model";
 import { ExpenseField } from 'src/app/core/models/intacct/db/expense-field.model';
-import { DependentFieldSetting, ImportSettingGet } from 'src/app/core/models/intacct/intacct-configuration/import-settings.model';
+import { DependentFieldSetting, ImportSettingGet, MappingSetting } from 'src/app/core/models/intacct/intacct-configuration/import-settings.model';
 import { LocationEntityMapping } from 'src/app/core/models/intacct/db/location-entity-mapping.model';
 import { GroupedDestinationAttribute } from "src/app/core/models/intacct/db/destination-attribute.model";
 import { IntacctConfiguration } from "src/app/core/models/db/configuration.model";
@@ -930,3 +930,11 @@ export const expenseFieldsExpectedForC1 = [
       source_placeholder: null
   }
 ];
+
+export const blankMapping: MappingSetting = {
+  source_field: '',
+  destination_field: '',
+  import_to_fyle: true,
+  is_custom: false,
+  source_placeholder: null
+};


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cwqhb69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced testing capabilities for the Intacct import settings component.
	- Introduced a new `blankMapping` constant for default mapping settings.

- **Bug Fixes**
	- Improved test coverage for saving import settings and handling errors.

- **Documentation**
	- Updated test cases to reflect new service methods and component interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->