### PR TITLE
fix: patch "Report Title" option to "Report Name" in skip export

### DIFF
--- a/src/app/shared/components/configuration/configuration-skip-export/configuration-skip-export.component.html
+++ b/src/app/shared/components/configuration/configuration-skip-export/configuration-skip-export.component.html
@@ -24,7 +24,7 @@
                   For options
                   <ng-template let-option pTemplate="item">
                     <span *ngIf="option.field_name !== 'claim_number'">
-                      {{ option.field_name | snakeCaseToSpaceCase | titlecase }}
+                      {{ (option.field_name === 'report_title' ? 'report_name' : option.field_name) | snakeCaseToSpaceCase | titlecase }}
                     </span>
                     <span *ngIf="option.field_name === 'claim_number'">
                       Report Number
@@ -33,7 +33,7 @@
                   For selected option
                   <ng-template let-selectedOption pTemplate="selectedItem">
                     <span *ngIf="selectedOption.field_name !== 'claim_number'">
-                      {{ selectedOption.field_name | snakeCaseToSpaceCase | titlecase }}
+                      {{ (selectedOption.field_name === 'report_title' ? 'report_name' : selectedOption.field_name) | snakeCaseToSpaceCase | titlecase }}
                     </span>
                     <span *ngIf="selectedOption.field_name === 'claim_number'">
                       Report Number

--- a/src/app/shared/components/si/helper/skip-export/skip-export.component.html
+++ b/src/app/shared/components/si/helper/skip-export/skip-export.component.html
@@ -23,11 +23,11 @@
                 <p-dropdown appendTo="body" [options]="conditionFieldOptions" formControlName="condition1" placeholder="Select Condition">
                   <!-- For options -->
                   <ng-template let-option pTemplate="item">
-                    {{ option.field_name | snakeCaseToSpaceCase | titlecase }}
+                    {{ (option.field_name === 'report_title' ? 'report_name' : option.field_name) | snakeCaseToSpaceCase | titlecase }}
                   </ng-template>
                   <!-- For selected option -->
                   <ng-template let-selectedOption pTemplate="selectedItem">
-                    {{ selectedOption.field_name | snakeCaseToSpaceCase | titlecase }}
+                    {{ (selectedOption.field_name === 'report_title' ? 'report_name' : selectedOption.field_name) | snakeCaseToSpaceCase | titlecase }}
                   </ng-template>
                 </p-dropdown>                               
                 <app-mandatory-error-message *ngIf="skipExportForm.controls.condition1.touched && !skipExportForm.controls.condition1.valid"


### PR DESCRIPTION
### Description
Affects advanced settings of intacct, netsuite, business central, qbo and sage 300

## Clickup
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated dropdown options to display 'report_name' instead of 'report_title' based on specific conditions.
  
- **Bug Fixes**
	- Ensured correct display of selected items in dropdowns for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->