### PR TITLE
fix: xero export settings payload bug

### DIFF
--- a/src/app/core/models/xero/xero-configuration/xero-export-settings.model.ts
+++ b/src/app/core/models/xero/xero-configuration/xero-export-settings.model.ts
@@ -215,7 +215,7 @@ export class XeroExportSettingModel {
         reimbursable_expense_state: exportSettingsForm.get('expenseState')?.value,
         reimbursable_export_date_type: exportSettingsForm.get('reimbursableExportDate')?.value ? exportSettingsForm.get('reimbursableExportDate')?.value : ExportDateType.CURRENT_DATE,
         ccc_expense_state: exportSettingsForm.get('cccExpenseState')?.value,
-        ccc_export_date_type: exportSettingsForm.get('creditCardExportDate')?.value ? exportSettingsForm.get('creditCardExportDate')?.value : ExportDateType.SPENT_AT,
+        ccc_export_date_type: exportSettingsForm.get('creditCardExportDate')?.value ? exportSettingsForm.get('creditCardExportDate')?.value : ExportDateType.SPENT_AT
       },
       workspace_general_settings: {
         reimbursable_expenses_object: exportSettingsForm.get('reimbursableExpense')?.value ? XeroReimbursableExpensesObject.PURCHASE_BILL : null,

--- a/src/app/core/models/xero/xero-configuration/xero-export-settings.model.ts
+++ b/src/app/core/models/xero/xero-configuration/xero-export-settings.model.ts
@@ -215,7 +215,7 @@ export class XeroExportSettingModel {
         reimbursable_expense_state: exportSettingsForm.get('expenseState')?.value,
         reimbursable_export_date_type: exportSettingsForm.get('reimbursableExportDate')?.value ? exportSettingsForm.get('reimbursableExportDate')?.value : ExportDateType.CURRENT_DATE,
         ccc_expense_state: exportSettingsForm.get('cccExpenseState')?.value,
-        ccc_export_date_type: exportSettingsForm.get('cccExportDate')?.value ? exportSettingsForm.get('cccExportDate')?.value : ExportDateType.SPENT_AT
+        ccc_export_date_type: exportSettingsForm.get('creditCardExportDate')?.value ? exportSettingsForm.get('creditCardExportDate')?.value : ExportDateType.SPENT_AT,
       },
       workspace_general_settings: {
         reimbursable_expenses_object: exportSettingsForm.get('reimbursableExpense')?.value ? XeroReimbursableExpensesObject.PURCHASE_BILL : null,


### PR DESCRIPTION
### Description
The export settings PUT payload always sent the default option for ccc export date type, `spent_at`. As a result, the CCC export date type could never be changed. This change fixes the incorrect field reference that caused it.

## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the export date type retrieval for credit card exports to enhance accuracy in data handling.

- **Bug Fixes**
	- Corrected the source of the export date type to ensure proper functionality in the export settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->