### PR TITLE
feat: add split expense grouping config to xero clone settings

### DIFF
--- a/src/app/integrations/xero/xero-onboarding/xero-clone-settings/xero-clone-settings.component.html
+++ b/src/app/integrations/xero/xero-onboarding/xero-clone-settings/xero-clone-settings.component.html
@@ -178,6 +178,21 @@
                         [tooltipText]="'The selected date will reflect in the corporate card expenses exported to Xero.'">
                     </app-clone-setting-field>
                 </div>
+        
+                <div class="clone-setting--field" *ngIf="brandingFeatureConfig.featureFlags.exportSettings.splitExpenseGrouping && 
+                    exportSettingForm.controls.creditCardExportType.value === XeroCorporateCreditCardExpensesObject.BANK_TRANSACTION">
+                    <app-clone-setting-field
+                        [iconSource]="'question-square-outline'"
+                        [label]="'How should the split expenses be grouped?'"
+                        [options]="splitExpenseGroupingOptions"
+                        [placeholder]="'Select split expense grouping'"
+                        [form]="exportSettingForm"
+                        [isFieldMandatory]="true"
+                        [formControllerName]="'splitExpenseGrouping'"
+                        [dropdownDisplayKey]="'label'"
+                        [tooltipText]="'The selected option will dictate how split expenses will be exported to Xero.'">
+                    </app-clone-setting-field>
+                </div>
             </div>
         </div>
     

--- a/src/app/integrations/xero/xero-onboarding/xero-clone-settings/xero-clone-settings.component.ts
+++ b/src/app/integrations/xero/xero-onboarding/xero-clone-settings/xero-clone-settings.component.ts
@@ -2,13 +2,13 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { forkJoin } from 'rxjs';
-import { brandingConfig, brandingContent } from 'src/app/branding/branding-config';
+import { brandingConfig, brandingContent, brandingFeatureConfig } from 'src/app/branding/branding-config';
 import { ExportSettingModel } from 'src/app/core/models/common/export-settings.model';
 import { ExpenseField, ImportSettingsModel } from 'src/app/core/models/common/import-settings.model';
 import { SelectFormOption } from 'src/app/core/models/common/select-form-option.model';
 import { DefaultDestinationAttribute, DestinationAttribute } from 'src/app/core/models/db/destination-attribute.model';
 import { FyleField, IntegrationField } from 'src/app/core/models/db/mapping.model';
-import { AppName, ConfigurationCta, ConfigurationWarningEvent, InputType, ToastSeverity, XeroFyleField } from 'src/app/core/models/enum/enum.model';
+import { AppName, ConfigurationCta, ConfigurationWarningEvent, InputType, ToastSeverity, XeroCorporateCreditCardExpensesObject, XeroFyleField } from 'src/app/core/models/enum/enum.model';
 import { ConfigurationWarningOut } from 'src/app/core/models/misc/configuration-warning.model';
 import { OnboardingStepper } from 'src/app/core/models/misc/onboarding-stepper.model';
 import { QBDEmailOptions } from 'src/app/core/models/qbd/qbd-configuration/qbd-advanced-setting.model';
@@ -40,6 +40,8 @@ export class XeroCloneSettingsComponent implements OnInit {
 
   brandingConfig = brandingConfig;
 
+  brandingFeatureConfig = brandingFeatureConfig;
+
   bankAccounts: DefaultDestinationAttribute[];
 
   reimbursableExportTypes = XeroExportSettingModel.getReimbursableExportTypes();
@@ -59,6 +61,8 @@ export class XeroCloneSettingsComponent implements OnInit {
   expenseStateOptions = XeroExportSettingModel.getReimbursableExpenseStateOptions();
 
   cccExpenseStateOptions = XeroExportSettingModel.getCCCExpenseStateOptions();
+
+  splitExpenseGroupingOptions = XeroExportSettingModel.getSplitExpenseGroupingOptions();
 
   exportSettingForm: FormGroup;
 
@@ -132,6 +136,8 @@ export class XeroCloneSettingsComponent implements OnInit {
   customFieldType: string;
 
   brandingContent = brandingContent;
+
+  XeroCorporateCreditCardExpensesObject = XeroCorporateCreditCardExpensesObject;
 
   constructor(
     private cloneSettingService: CloneSettingService,


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cx0vk02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new field for grouping split expenses when exporting to Xero, enhancing expense management for corporate credit card transactions.
	- Added options for selecting how split expenses should be grouped, with user-friendly labels and tooltips for guidance.

- **Bug Fixes**
	- Improved state management in the XeroCloneSettingsComponent for better initialization and handling of expense grouping options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->