### PR TITLE
fix: fix payload and display of dynamic fields in xero clone settings

### DIFF
--- a/src/app/core/models/xero/xero-configuration/clone-setting.model.ts
+++ b/src/app/core/models/xero/xero-configuration/clone-setting.model.ts
@@ -24,6 +24,12 @@ export class XeroCloneSettingModel {
         const importSettingPayload = XeroImportSettingModel.constructPayload(importSettingForm);
         const advancedSettingPayload = XeroAdvancedSettingModel.constructPayload(advancedSettingForm);
 
+        // Set the bank_account in the payload to the selected field value without formatting it
+        // Since we format them on component init (clone settings only)
+        exportSettingPayload.general_mappings.bank_account = exportSettingForm.get('bankAccount')?.value;
+        importSettingPayload.general_mappings.default_tax_code = importSettingForm.get('defaultTaxCode')?.value;
+        advancedSettingPayload.general_mappings.payment_account = advancedSettingForm.get('billPaymentAccount')?.value;
+
         if (!isTaxGroupSyncAllowed) {
             importSettingPayload.workspace_general_settings.import_tax_codes = false;
         }

--- a/src/app/integrations/xero/xero-onboarding/xero-clone-settings/xero-clone-settings.component.ts
+++ b/src/app/integrations/xero/xero-onboarding/xero-clone-settings/xero-clone-settings.component.ts
@@ -365,6 +365,20 @@ export class XeroCloneSettingsComponent implements OnInit {
       this.advancedSettingForm = XeroAdvancedSettingModel.mapAPIResponseToFormGroup(this.cloneSetting.advanced_settings, this.adminEmails, destinationAttributes.BANK_ACCOUNT);
       this.setupAdvancedSettingFormWatcher();
 
+      // Convert field values from destination attributes to *default* destination attributes
+      const controls = [
+        this.exportSettingForm.get('bankAccount'),
+        this.importSettingForm.get('defaultTaxCode'),
+        this.advancedSettingForm.get('billPaymentAccount')
+      ];
+
+      for (const control of controls) {
+        const fullDestinationAttribute: DestinationAttribute | null = control?.value;
+        control?.setValue(
+          fullDestinationAttribute && ExportSettingModel.formatGeneralMappingPayload(fullDestinationAttribute)
+        );
+      }
+
       this.isLoading = false;
     });
   }


### PR DESCRIPTION
### Description
Problem: Dynamic fields that use destination attributes were unusable in Xero clone settings

Cause: Export settings and clone settings use different formats to store destination attributes. However, the same methods were used to ingest data and build the payload

Solution: Patch the values in clone settings - while setting the default form values and while building the payload

## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced payload construction for clone settings, ensuring specific fields are included directly from form groups.
	- Improved handling of destination attributes in the Xero Clone Settings component, allowing for better data management and formatting.

- **Bug Fixes**
	- Maintained existing logic for onboarding steps and form validation, ensuring consistent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->