### PR TITLE
fix: show either import or export merchants in xero

### DIFF
--- a/src/app/core/models/xero/db/xero-workspace-general-setting.model.ts
+++ b/src/app/core/models/xero/db/xero-workspace-general-setting.model.ts
@@ -11,6 +11,7 @@ export type XeroWorkspaceGeneralSetting = {
     map_merchant_to_contact: boolean;
     auto_map_employees: string;
     auto_create_destination_entity: boolean;
+    auto_create_merchant_destination_entity: boolean;
     is_simplify_report_closure_enabled: boolean;
     skip_cards_mapping?: boolean;
     import_tax_codes: boolean;

--- a/src/app/integrations/xero/xero-shared/xero-advanced-settings/xero-advanced-settings.component.html
+++ b/src/app/integrations/xero/xero-shared/xero-advanced-settings/xero-advanced-settings.component.html
@@ -92,7 +92,7 @@
                     [placeholder]="'Select a Payment Account'"
                     [formControllerName]="'billPaymentAccount'">
                 </app-configuration-select-field>
-                <app-configuration-toggle-field *ngIf="workspaceGeneralSettings.corporate_credit_card_expenses_object"
+                <app-configuration-toggle-field *ngIf="workspaceGeneralSettings.corporate_credit_card_expenses_object && !workspaceGeneralSettings.import_suppliers_as_merchants"
                     [form]="advancedSettingForm"
                     [iconPath]="'user-plus'"
                     [label]="brandingContent.autoCreateMerchantsAsVendorsLabel"

--- a/src/app/integrations/xero/xero-shared/xero-import-settings/xero-import-settings.component.html
+++ b/src/app/integrations/xero/xero-shared/xero-import-settings/xero-import-settings.component.html
@@ -49,7 +49,11 @@
                     </div>
                 </div>
 
-                <div class="tw-rounded-lg tw-border-border-tertiary tw-border tw-mt-24-px" *ngIf="brandingFeatureConfig.featureFlags.importSettings.importVendorsAsMerchants && workspaceGeneralSettings.corporate_credit_card_expenses_object">
+                <div
+                    class="tw-rounded-lg tw-border-border-tertiary tw-border tw-mt-24-px"
+                    *ngIf="brandingFeatureConfig.featureFlags.importSettings.importVendorsAsMerchants 
+                        && workspaceGeneralSettings.corporate_credit_card_expenses_object
+                        && !workspaceGeneralSettings.auto_create_merchant_destination_entity">
                     <app-configuration-toggle-field
                         [form]="importSettingsForm"
                         [label]="brandingContent.importSuppliersAsMerchantsLabel"


### PR DESCRIPTION
### Description
We have two fields in Xero that control the import and export of Merchants:

In import settings
<img width="619" alt="image" src="https://github.com/user-attachments/assets/f2a97970-1b67-4dba-be94-2489c0b6dcec">


In advanced settings
<img width="608" alt="image" src="https://github.com/user-attachments/assets/7d8d053e-5c8d-410d-aeea-c32c94f26997">


With this change, only one of the two fields can be enabled at the same time. If one is enabled, the other will be hidden.

## Clickup
https://app.clickup.com/t/86cx49er1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new setting for auto-creating merchant destination entities in Xero workspace settings.
- **Improvements**
	- Updated the conditions for displaying the toggle for corporate credit card expenses in advanced settings.
	- Simplified the display logic for the vendor import toggle in import settings, now considering the new auto-create setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->