### PR TITLE
fix: remove the posted at date option for ccc expenses grouped by report

### DIFF
--- a/src/app/integrations/business-central/business-central-shared/business-central-export-settings/business-central-export-settings.component.ts
+++ b/src/app/integrations/business-central/business-central-shared/business-central-export-settings/business-central-export-settings.component.ts
@@ -142,7 +142,7 @@ export class BusinessCentralExportSettingsComponent implements OnInit {
     if (this.exportSettingForm.controls[formControllerName].value === ExpenseGroupedBy.EXPENSE) {
       return options.filter(option => option.value !== ExportDateType.LAST_SPENT_AT);
     }
-    return options.filter(option => option.value !== ExportDateType.SPENT_AT);
+    return options.filter(option => (option.value !== ExportDateType.SPENT_AT && option.value !== ExportDateType.POSTED_AT));
   }
 
   refreshDimensions(isRefresh: boolean): void{
@@ -161,6 +161,12 @@ export class BusinessCentralExportSettingsComponent implements OnInit {
       if (brandingConfig.brandId==='fyle') {
         this.cccExpenseGroupingDateOptions = BusinessCentralExportSettingModel.getCCCExpenseGroupingDateOptions();
         this.cccExpenseGroupingDateOptions = ExportSettingModel.constructGroupingDateOptions(cccExportGroup, this.cccExpenseGroupingDateOptions);
+
+        // If the selected value is not valid after the export group change, reset the field
+        const visibleValues = this.getExportDate(this.cccExpenseGroupingDateOptions, 'cccExportGroup').map(option => option.value);
+        if (!visibleValues.includes(this.exportSettingForm.get('cccExportDate')?.value)) {
+          this.exportSettingForm.get('cccExportDate')?.reset();
+        }
       }
     });
   }


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cx5t0y4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced filtering criteria for export dates in the export settings component.
	- Added logic to reset the export date field when an invalid selection is made.

- **Bug Fixes**
	- Improved form consistency by preventing invalid selections in the export settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->