### PR TITLE
fix: initialize chart of accounts multiselect when there is no api response

### DIFF
--- a/src/app/core/models/business-central/business-central-configuration/business-central-import-settings.model.ts
+++ b/src/app/core/models/business-central/business-central-configuration/business-central-import-settings.model.ts
@@ -26,7 +26,7 @@ export class BusinessCentralImportSettingsModel extends ImportSettingsModel {
         const expenseFieldsArray = importSettings?.mapping_settings ? this.constructFormArray(importSettings.mapping_settings, businessCentralFields) : [] ;
         return new FormGroup({
             importCategories: new FormControl(importSettings?.import_settings?.import_categories ?? false),
-            chartOfAccountTypes: new FormControl(importSettings?.import_settings.charts_of_accounts ? importSettings?.import_settings.charts_of_accounts : ['Expense']),
+            chartOfAccountTypes: new FormControl(importSettings?.import_settings?.charts_of_accounts ? importSettings?.import_settings?.charts_of_accounts : ['Expense']),
             importVendorAsMerchant: new FormControl(importSettings?.import_settings?.import_vendors_as_merchants ?? false ),
             expenseFields: new FormArray(expenseFieldsArray)
         });


### PR DESCRIPTION
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved null safety for accessing the charts of accounts property in the import settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->