### PR TITLE
fix: hide card number and employee name as options for memo field

### DIFF
--- a/src/app/core/models/common/advanced-settings.model.ts
+++ b/src/app/core/models/common/advanced-settings.model.ts
@@ -5,7 +5,7 @@ import { ExportSettingGet } from "../intacct/intacct-configuration/export-settin
 import { QBOExportSettingGet } from "../qbo/qbo-configuration/qbo-export-setting.model";
 import { NetSuiteExportSettingGet } from "../netsuite/netsuite-configuration/netsuite-export-setting.model";
 import { IntacctConfiguration } from "../db/configuration.model";
-
+import { brandingConfig } from 'src/app/branding/branding-config';
 export type EmailOption = {
     email: string;
     name: string;
@@ -88,7 +88,7 @@ export class AdvancedSettingsModel {
       cccExportType = exportSettings.workspace_general_settings?.corporate_credit_card_expenses_object ?? undefined;
     }
     // Filter out options based on cccExportType and appName
-    if (cccExportType && ['netsuite', 'quickbooks online', 'sage intacct'].includes(appName.toLowerCase())) {
+    if (cccExportType && ['netsuite', 'quickbooks online', 'sage intacct'].includes(appName.toLowerCase()) && brandingConfig.brandId === 'fyle') {
       return defaultOptions; // Allow all options including 'card_number'
     }
       return defaultOptions.filter(option => option !== 'card_number'); // Omit 'card_number' for other apps

--- a/src/app/core/models/common/advanced-settings.model.ts
+++ b/src/app/core/models/common/advanced-settings.model.ts
@@ -88,14 +88,14 @@ export class AdvancedSettingsModel {
       cccExportType = exportSettings.workspace_general_settings?.corporate_credit_card_expenses_object ?? undefined;
     }
 
-    if(brandingConfig.brandId === 'co') {
+    if (brandingConfig.brandId === 'co') {
       return defaultOptions.filter(option => option !== 'card_number' && option !== 'employee_name');
-    } else {
+    }
       if (cccExportType && ['netsuite', 'quickbooks online', 'sage intacct'].includes(appName.toLowerCase()) && brandingConfig.brandId === 'fyle') {
         return defaultOptions;
       }
       return defaultOptions.filter(option => option !== 'card_number');
-    }
+
   }
 
   static formatMemoPreview(memoStructure: string[], defaultMemoOptions: string[]): [string, string[]] {

--- a/src/app/core/models/common/advanced-settings.model.ts
+++ b/src/app/core/models/common/advanced-settings.model.ts
@@ -87,12 +87,15 @@ export class AdvancedSettingsModel {
     } else if ('workspace_general_settings' in exportSettings) {
       cccExportType = exportSettings.workspace_general_settings?.corporate_credit_card_expenses_object ?? undefined;
     }
-    // Filter out options based on cccExportType and appName
-    if (cccExportType && ['netsuite', 'quickbooks online', 'sage intacct'].includes(appName.toLowerCase()) && brandingConfig.brandId === 'fyle') {
-      return defaultOptions; // Allow all options including 'card_number'
-    }
-      return defaultOptions.filter(option => option !== 'card_number'); // Omit 'card_number' for other apps
 
+    if(brandingConfig.brandId === 'co') {
+      return defaultOptions.filter(option => option !== 'card_number' && option !== 'employee_name');
+    } else {
+      if (cccExportType && ['netsuite', 'quickbooks online', 'sage intacct'].includes(appName.toLowerCase()) && brandingConfig.brandId === 'fyle') {
+        return defaultOptions;
+      }
+      return defaultOptions.filter(option => option !== 'card_number');
+    }
   }
 
   static formatMemoPreview(memoStructure: string[], defaultMemoOptions: string[]): [string, string[]] {


### PR DESCRIPTION
### Description
- hide card number and employee name as options for memo field

## Clickup
- app.clickup.com/t/86cx0x4rp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced memo options control based on branding configuration, allowing additional options for specific brands.

- **Bug Fixes**
	- Improved logic for filtering memo options based on brand ID, ensuring correct options are displayed based on the selected brand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->