### PR TITLE
fix: update incorrect memo structure key in sage300 advanced settings payload

### DIFF
--- a/src/app/core/models/sage300/sage300-configuration/sage300-advanced-settings.model.ts
+++ b/src/app/core/models/sage300/sage300-configuration/sage300-advanced-settings.model.ts
@@ -3,7 +3,7 @@ import { ExpenseFilterPost, ExpenseFilterPayload, ConditionField } from "../../c
 import { JoinOption, Operator } from "../../enum/enum.model";
 
 export type Sage300AdvancedSetting = {
-  memo_structure: string[],
+  expense_memo_structure: string[],
   schedule_is_enabled: boolean,
   auto_create_vendor: boolean,
   interval_hours: number
@@ -23,7 +23,7 @@ export class Sage300AdvancedSettingModel {
   static mapAPIResponseToFormGroup(advancedSettings: Sage300AdvancedSettingGet | null, isSkipExportEnabled: boolean): FormGroup {
     const defaultMemoOptions: string[] = ['employee_email', 'purpose', 'category', 'spent_on', 'report_number', 'expense_link'];
     return new FormGroup({
-      memoStructure: new FormControl(advancedSettings?.memo_structure ? advancedSettings?.memo_structure : defaultMemoOptions),
+      memoStructure: new FormControl(advancedSettings?.expense_memo_structure ? advancedSettings?.expense_memo_structure : defaultMemoOptions),
       scheduleEnabled: new FormControl(advancedSettings?.schedule_is_enabled ? true : false),
       autoCreateVendor: new FormControl(advancedSettings?.auto_create_vendor ? true : false),
       scheduleAutoExportFrequency: new FormControl(advancedSettings?.interval_hours ? advancedSettings.interval_hours : 1),
@@ -33,7 +33,7 @@ export class Sage300AdvancedSettingModel {
 
   static createAdvancedSettingPayload(advancedSettingsForm: FormGroup): Sage300AdvancedSettingPost {
     return {
-      memo_structure: advancedSettingsForm.get('memoStructure')?.value ? advancedSettingsForm.get('memoStructure')?.value : null,
+      expense_memo_structure: advancedSettingsForm.get('memoStructure')?.value ? advancedSettingsForm.get('memoStructure')?.value : null,
       schedule_is_enabled: advancedSettingsForm.get('scheduleEnabled')?.value ? advancedSettingsForm.get('scheduleEnabled')?.value : false,
       interval_hours: advancedSettingsForm.get('scheduleEnabled')?.value ? advancedSettingsForm.get('scheduleAutoExportFrequency')?.value : null,
       auto_create_vendor: advancedSettingsForm.get('autoCreateVendor')?.value ? advancedSettingsForm.get('autoCreateVendor')?.value : false

--- a/src/app/integrations/sage300/sage300-shared/fixture.ts
+++ b/src/app/integrations/sage300/sage300-shared/fixture.ts
@@ -72,7 +72,7 @@ export const sage300FieldsResponse: IntegrationField[] =
 ];
 
 export const sage300AdvancedSettingResponse: Sage300AdvancedSettingGet = {
-    memo_structure: [
+    expense_memo_structure: [
         "employee_email",
         "category",
         "spent_on",


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cxd612w


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `memo_structure` property to `expense_memo_structure` in Sage 300 advanced settings model and fixture
	- Updated related method references to use the new property name
	- Ensured consistent naming across model and methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->