### PR TITLE
feat: only show top level when multiple location entity

### DIFF
--- a/src/app/shared/components/si/core/intacct-location-entity/intacct-location-entity.component.ts
+++ b/src/app/shared/components/si/core/intacct-location-entity/intacct-location-entity.component.ts
@@ -145,7 +145,7 @@ export class IntacctLocationEntityComponent implements OnInit {
     this.mappingsService.getSageIntacctDestinationAttributes(IntacctField.LOCATION_ENTITY).subscribe((locationEntities) => {
       const topLevelOption = {
         id: 1,
-        attribute_type: 'LOCATION_ENTITY', 
+        attribute_type: 'LOCATION_ENTITY',
         display_name: 'Location Entity',
         destination_id: 'top_level',
         value: 'Top Level',
@@ -155,12 +155,12 @@ export class IntacctLocationEntityComponent implements OnInit {
         workspace: this.workspaceId,
         detail: {}
       };
-  
+
       // Only add top level option if there are multiple location entities
-      this.locationEntityOptions = locationEntities.length > 1 
+      this.locationEntityOptions = locationEntities.length > 1
         ? [topLevelOption].concat(locationEntities)
         : locationEntities;
-  
+
       this.setupLocationEntityMapping();
     });
   }

--- a/src/app/shared/components/si/core/intacct-location-entity/intacct-location-entity.component.ts
+++ b/src/app/shared/components/si/core/intacct-location-entity/intacct-location-entity.component.ts
@@ -145,7 +145,7 @@ export class IntacctLocationEntityComponent implements OnInit {
     this.mappingsService.getSageIntacctDestinationAttributes(IntacctField.LOCATION_ENTITY).subscribe((locationEntities) => {
       const topLevelOption = {
         id: 1,
-        attribute_type: 'LOCATION_ENTITY',
+        attribute_type: 'LOCATION_ENTITY', 
         display_name: 'Location Entity',
         destination_id: 'top_level',
         value: 'Top Level',
@@ -155,7 +155,12 @@ export class IntacctLocationEntityComponent implements OnInit {
         workspace: this.workspaceId,
         detail: {}
       };
-      this.locationEntityOptions = [topLevelOption].concat(locationEntities);
+  
+      // Only add top level option if there are multiple location entities
+      this.locationEntityOptions = locationEntities.length > 1 
+        ? [topLevelOption].concat(locationEntities)
+        : locationEntities;
+  
       this.setupLocationEntityMapping();
     });
   }


### PR DESCRIPTION
### Description
- only show top level when multiple location entity

## Clickup
- https://app.clickup.com/t/top-level-hidden-conditionally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved location entity selection logic by conditionally displaying top-level options based on the number of available location entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->