### PR TITLE
fix: employee mapping field not populating on page load

### DIFF
--- a/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
@@ -54,8 +54,6 @@ export class QboExportSettingsComponent implements OnInit {
 
   isImportItemsEnabled: boolean;
 
-  reimbursableExportTypes: SelectFormOption[];
-
   creditCardExportTypes = QBOExportSettingModel.getCreditCardExportTypes();
 
   cccExpenseStateOptions = QBOExportSettingModel.getCCCExpenseStateOptions();
@@ -498,7 +496,7 @@ return of(null);
     ]).subscribe(([exportSetting, workspaceGeneralSettings, destinationAttributes, bankAccounts, cccAccounts, accountsPayables, vendors]) => {
 
       this.exportSettings = exportSetting;
-      this.employeeFieldMapping = workspaceGeneralSettings?.employee_field_mapping || EmployeeFieldMapping.EMPLOYEE;
+      this.employeeFieldMapping = workspaceGeneralSettings?.employee_field_mapping;
       this.setLiveEntityExample(destinationAttributes);
       this.bankAccounts = bankAccounts.results.map((option) => QBOExportSettingModel.formatGeneralMappingPayload(option));
       this.cccAccounts = cccAccounts.results.map((option) => QBOExportSettingModel.formatGeneralMappingPayload(option));
@@ -508,7 +506,6 @@ return of(null);
 
       this.isImportItemsEnabled = workspaceGeneralSettings?.import_items || false;
 
-      this.reimbursableExportTypes = QBOExportSettingModel.getReimbursableExportTypeOptions(this.employeeFieldMapping);
       this.showNameInJournalOption = this.exportSettings.workspace_general_settings?.corporate_credit_card_expenses_object === QBOCorporateCreditCardExpensesObject.JOURNAL_ENTRY ? true : false;
 
       this.addMissingOptions();

--- a/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
@@ -514,7 +514,7 @@ return of(null);
       this.addMissingOptions();
       this.exportSettingForm = QBOExportSettingModel.mapAPIResponseToFormGroup(this.exportSettings, this.employeeFieldMapping);
       this.employeeSettingForm = QBOExportSettingModel.createEmployeeSettingsForm(
-        this.existingEmployeeFieldMapping,
+        this.employeeFieldMapping,
         workspaceGeneralSettings?.auto_map_employees || false
       );
       if (!this.brandingFeatureConfig.featureFlags.exportSettings.reimbursableExpenses) {


### PR DESCRIPTION
### Description
Fix bug where the employee mapping field was left blank on page load

## Clickup
https://app.clickup.com/t/86cxrzmgb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Removed outdated reimbursable export types property.
	- Updated employee settings form initialization to use the correct field mapping source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->