### PR TITLE
fix: casing bug in field initialization making the field display 'null'

### DIFF
--- a/src/app/core/models/xero/xero-configuration/xero-import-settings.model.ts
+++ b/src/app/core/models/xero/xero-configuration/xero-import-settings.model.ts
@@ -80,7 +80,7 @@ export class XeroImportSettingModel extends ImportSettingsModel {
     return new FormGroup({
       importCategories: new FormControl(importSettings?.workspace_general_settings.import_categories ?? false),
       expenseFields: new FormArray(expenseFieldsArray),
-      chartOfAccountTypes: new FormControl(importSettings?.workspace_general_settings.charts_of_accounts ? importSettings.workspace_general_settings.charts_of_accounts.map((account) => account.toUpperCase()) : ['EXPENSE']),
+      chartOfAccountTypes: new FormControl(importSettings?.workspace_general_settings.charts_of_accounts ? importSettings.workspace_general_settings.charts_of_accounts.map((name: string) => name[0]+name.substr(1).toLowerCase()) : ['Expense']),
       importCustomers: new FormControl(importSettings?.workspace_general_settings.import_customers ?? false),
       taxCode: new FormControl(importSettings?.workspace_general_settings.import_tax_codes ?? false),
       importSuppliersAsMerchants: new FormControl(importSettings?.workspace_general_settings.import_suppliers_as_merchants ?? false),


### PR DESCRIPTION
### Description
API response and payload: `['EXPENSE', 'ASSET', 'EQUITY', 'LIABILITY', 'REVENUE']`
Field options: `['Expense', 'Asset', 'Equity', 'Liability', 'Revenue']`

- We are transforming the options to uppercase for the payload, 
- But we were not transforming the API response from uppercase to titlecase so that it matches with the field's options

## Clickup
https://app.clickup.com/t/86cy21712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the display of account names to use proper capitalization, improving readability while keeping default settings unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->