### PR TITLE
fix: hide duplicate options in dropdown

### DIFF
--- a/src/app/shared/components/menu/main-menu/main-menu.component.ts
+++ b/src/app/shared/components/menu/main-menu/main-menu.component.ts
@@ -95,12 +95,13 @@ export class MainMenuComponent implements OnInit {
 
     /**
      * Iterate backwards because the most recently connected integration
-     * at integrations[0] should be unshifted last
+     * at integrations[0] should be unshifted last (to make it the first option)
      */
     for (let i = integrations.length - 1; i >= 0; i--) {
       const integration = integrations[i];
       const integrationName = this.integrationsService.getIntegrationName(integration.tpa_name);
-      if (integrationName === null) {
+      const existingOptions = options[0].items.map(i => i.label);
+      if (integrationName === null || existingOptions.includes(integrationName)) {
         continue;
       }
 


### PR DESCRIPTION
### Description
Integrations table having duplicate integration records (on integrations reset, for example) caused duplicate options in the "More" dropdown. This makes sure we show only unique options.

## Clickup
https://app.clickup.com/t/86cy5xqhn