### PR TITLE
fix: incorrect base API urls on page refresh

### DIFF
--- a/src/app/core/services/common/api.service.ts
+++ b/src/app/core/services/common/api.service.ts
@@ -21,6 +21,10 @@ export class ApiService {
     private http: HttpClient
   ) { }
 
+  getBaseApiURL(): string {
+    return API_BASE_URL;
+  }
+
   setBaseApiURL(url: string): void {
     API_BASE_URL = url;
   }

--- a/src/app/core/services/common/integrations.service.ts
+++ b/src/app/core/services/common/integrations.service.ts
@@ -62,7 +62,15 @@ export class IntegrationsService {
 
   @Cacheable()
   getIntegrations(): Observable<Integration[]> {
+    // Store the existing base API URL
+    const previousBaseApiUrl = this.apiService.getBaseApiURL();
+
+    // Set the base API URL to the integrations URL
     this.helper.setBaseApiURL(AppUrl.INTEGRATION);
-    return this.apiService.get(`/integrations/`, {});
+    const integrationsObservable = this.apiService.get(`/integrations/`, {});
+
+    // Reset the base API URL to the previous one, so that the following requests are not affected
+    this.apiService.setBaseApiURL(previousBaseApiUrl);
+    return integrationsObservable;
   }
 }


### PR DESCRIPTION
### Bug
1. Go to settings -> native apps -> intacct -> export settings
2. Refresh the page
3. GET paginated destination attributes was being called with the incorrect base API url (integrations-api instead of intacct-api)

This might exist in other apps as well

### Cause
- A new `GET /integrations` call was added
- This required setting the base API url to `integrations-api`
- Any subsequent calls would also use the same base url
- This causes the paginated destination attributes call to go to `integrations-api` instead of `intacct-api`

### Fix
While performing `GET /integrations`, stash the current base url and restore it after the call is done

## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new capability to retrieve the current API base URL, offering clearer access to API configuration settings.
  
- **Refactor**
  - Enhanced the integration process to temporarily adjust API settings during external calls, ensuring that subsequent operations continue seamlessly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->