### PR TITLE
fix: logo and button width for all screen sizes

### DIFF
--- a/src/app/shared/components/helper/app-landing-page-header/app-landing-page-header.component.html
+++ b/src/app/shared/components/helper/app-landing-page-header/app-landing-page-header.component.html
@@ -4,7 +4,7 @@
 <div class="tw-p-24-px tw-text-slightly-normal-text-color">
     <div class="tw-h-68-px tw-flex tw-justify-between">
             <div class="tw-flex">
-                <div class="tw-flex tw-justify-center" [ngClass]="logoSectionStyleClasses">
+                <div class="tw-flex tw-justify-center" [ngClass]="logoSectionStyleClasses + ' tw-shrink-0'">
                     <img src="{{ iconPath }}" width="logoWidth" height="44px" [ngClass]="logoStyleClasses" />
                 </div>
                 <div class="tw-pl-16-px tw-flex tw-flex-col">
@@ -31,7 +31,7 @@
                     </div>
                 </div>
             </div>
-            <div *ngIf="!isIntegrationSetupInProgress && !isLoading && !showErrorScreen " class="tw-flex tw-items-center">
+            <div *ngIf="!isIntegrationSetupInProgress && !isLoading && !showErrorScreen " class="tw-flex tw-items-center tw-shrink-0">
                 <button *ngIf="!isIntegrationConnected && (appName === AppName.BAMBOO_HR || appName === AppName.TRAVELPERK)" pButton type="button" class="p-button-raised" (click)="connect()" [disabled]="isConnectionInProgress">
                     {{ isConnectionInProgress ? 'Connecting' : 'Connect' }}
                     <app-svg-icon *ngIf="!isConnectionInProgress && brandingFeatureConfig.isIconsInsideButtonAllowed" [svgSource]="'arrow-tail-right-medium'" [width]="'18px'" [height]="'18px'" [styleClasses]="'tw-pl-10-px tw-pt-2-px !tw-text-12-px'"></app-svg-icon>


### PR DESCRIPTION
### Description
Fix the logo and button width, regardless of screen sizes (for both c1 and fyle theme)

Before:
![image](https://github.com/user-attachments/assets/0c2ade53-2a30-47c5-804b-e328a41f79fd)

After:
![image](https://github.com/user-attachments/assets/5b96f1a1-bab5-4fd4-b129-97ea1aa7b654)




## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the landing page header layout for improved responsiveness. Key areas now maintain consistent spacing and visual balance, ensuring a stable and appealing display across various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->