### PR TITLE
fix: remove 'Connect' text on BC tile hover

### DIFF
--- a/src/app/integrations/landing-v2/landing-v2.component.html
+++ b/src/app/integrations/landing-v2/landing-v2.component.html
@@ -42,11 +42,6 @@
                 (click)="openInAppIntegration(InAppIntegration.BUSINESS_CENTRAL)">
                 <div class="tw-flex tw-justify-between tw-items-center">
                     <img src="assets/logos/BusinessCentral-logo.svg" />
-                    @if (isAppConnected('BUSINESS_CENTRAL')) {
-                        <app-badge text="Connected" [theme]="ThemeOption.SUCCESS"></app-badge>
-                    } @else {
-                        <button class="btn-connect">Connect</button>
-                    }
                 </div>
                 <span class="landing-v2--accounting-app-name tw-items-start tw-gap-[10px] !tw-text-12-px">
                     <div>


### PR DESCRIPTION
### Description
We don't support showing the connected status for business central since we plan to deprecate the integration. For now, we are hiding the 'Connect' text when the tile is hovered for BC only.

### Before
![image](https://github.com/user-attachments/assets/3db5642d-c66d-49a5-89b8-d22f2697bb51)

### After
![image](https://github.com/user-attachments/assets/46359e1c-db8f-4edd-a7d5-ff1b38ce1681)


## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the landing interface by removing the connection status indicators for a specific integration. The application logo remains clickable, while visual cues for connection status are no longer displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->