### PR TITLE
fix: netsuite custom segment dialog placeholder

### DIFF
--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-custom-segment-dialog/netsuite-custom-segment-dialog.component.html
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-import-settings/netsuite-custom-segment-dialog/netsuite-custom-segment-dialog.component.html
@@ -3,7 +3,7 @@
         <p-dialog header="Header" [dismissableMask]="true" [(visible)]="isCustomSegmentDialogVisible" [showHeader]="true" [modal]="true" (onHide)="close()" [breakpoints]="{ '960px': '75vw' }" [draggable]="false" [style]="{ width: '800px', height: '900px' }">
             <ng-template pTemplate="header">
                 <div>
-                   <span class="tw-text-20-px tw-font-500 tw-text-modal-header-text-color">{{brandingContent.customSegmentHeader}}</span> 
+                   <span class="tw-text-20-px tw-font-500 tw-text-modal-header-text-color">{{brandingContent.customSegmentHeader}}</span>
                 </div>
             </ng-template>
             <div *ngIf="isLoading" class="tw-flex tw-justify-center tw-items-center tw-h-5/6">
@@ -50,10 +50,10 @@
                     <div *ngIf="isInternalIDSelectionActive">
                         <div class="tw-mb-14-px">
                             <div class="tw-mb-10-px">
-                                <app-mandatory-field></app-mandatory-field><label for="" class="tw-text-14-px tw-text-form-label-text-color tw-font-400 tw-ml-6-px">Enter {{ this.form.controls.customFieldType.value | snakeCaseToSpaceCase | lowercase }} internal id</label>
+                                <app-mandatory-field></app-mandatory-field><label for="" class="tw-text-14-px tw-text-form-label-text-color tw-font-400 tw-ml-6-px">Enter {{ this.form.controls.customFieldType.value | snakeCaseToSpaceCase | lowercase }} Internal ID</label>
                             </div>
                             <div>
-                                <input type="text" class="tw-border-box-color" [ngClass]="[form.controls.internalId.invalid && form.controls.internalId.touched ? 'error-box' : 'normal-box']"  pInputText formControlName="internalId" [placeholder]="'Enter {{ this.form.controls.customFieldType.value | snakeCaseToSpaceCase | lowercase }} internal id'" required>
+                                <input type="text" class="tw-border-box-color" [ngClass]="[form.controls.internalId.invalid && form.controls.internalId.touched ? 'error-box' : 'normal-box']"  pInputText formControlName="internalId" placeholder="Enter Internal ID" required>
                                 <app-mandatory-error-message *ngIf="form.controls.internalId.touched && !form.controls.internalId.valid && !form.controls.internalId.disabled" [customErrorMessage]="'Please enter internal id'"></app-mandatory-error-message>
                             </div>
                         </div>


### PR DESCRIPTION
### Before
![image](https://github.com/user-attachments/assets/6540905d-da6c-46ac-9071-4a755e8b9ba4)

### After
![image](https://github.com/user-attachments/assets/4853b868-4cf9-4020-b8dd-2f6b9c55b924)


## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the user interface by standardizing labels and input placeholders for internal IDs. The label now displays "Internal ID" with proper capitalization, and the placeholder has been simplified to "Enter Internal ID" for a clearer and more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->