### PR TITLE
feat: show display names in intacct > mapping > tab switcher

### DIFF
--- a/src/app/core/models/db/dimension-details.model.ts
+++ b/src/app/core/models/db/dimension-details.model.ts
@@ -1,0 +1,15 @@
+import { PaginatedResponse } from "./paginated-response.model";
+
+export type DimensionDetail = {
+    id: number;
+    attribute_type: string;
+    display_name: string;
+    source_type: string;
+    created_at: string;
+    updated_at: string;
+    workspace: number;
+};
+
+export interface PaginatedDimensionDetails extends PaginatedResponse {
+    results: DimensionDetail[];
+}

--- a/src/app/core/models/enum/enum.model.ts
+++ b/src/app/core/models/enum/enum.model.ts
@@ -321,6 +321,8 @@ export enum FyleField {
   EMPLOYEE = 'EMPLOYEE',
   VENDOR = 'VENDOR',
   CATEGORY = 'CATEGORY',
+  PROJECT = 'PROJECT',
+  COST_CENTER = 'COST_CENTER'
 }
 
 export enum NetsuiteCustomSegmentOption {

--- a/src/app/core/services/common/common-resources.service.spec.ts
+++ b/src/app/core/services/common/common-resources.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CommonResourcesService } from './common-resources.service';
+
+describe('CommonResourcesService', () => {
+  let service: CommonResourcesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CommonResourcesService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/common/common-resources.service.ts
+++ b/src/app/core/services/common/common-resources.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { ApiService } from './api.service';
+import { HelperService } from './helper.service';
+import { WorkspaceService } from './workspace.service';
+import { Observable } from 'rxjs';
+import { PaginatedDimensionDetails } from '../../models/db/dimension-details.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CommonResourcesService {
+
+  constructor(
+    private apiService: ApiService,
+    private workspaceService: WorkspaceService,
+    private helper: HelperService
+  ) { }
+
+  getDimensionDetails(
+    { attributeTypes, sourceType }:
+    { attributeTypes: string[], sourceType: 'FYLE' | 'ACCOUNTING' }
+  ): Observable<PaginatedDimensionDetails> {
+    this.helper.setBaseApiURL();
+
+    const params: Record<string, string[] | string | number> = {
+      attribute_type__in: attributeTypes,
+      source_type: sourceType,
+      offset: 0,
+      limit: 100
+    };
+
+    return this.apiService.get(`/workspaces/${this.workspaceService.getWorkspaceId()}/common_resources/dimension_details/`, params);
+  }
+}

--- a/src/app/integrations/intacct/intacct-main/intacct-mapping/intacct-mapping.component.ts
+++ b/src/app/integrations/intacct/intacct-main/intacct-mapping/intacct-mapping.component.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import { MenuItem } from 'primeng/api';
 import { brandingConfig, brandingFeatureConfig, brandingStyle } from 'src/app/branding/branding-config';
 import { FyleField } from 'src/app/core/models/enum/enum.model';
+import { CommonResourcesService } from 'src/app/core/services/common/common-resources.service';
 import { SiMappingsService } from 'src/app/core/services/si/si-core/si-mappings.service';
 import { SentenceCasePipe } from 'src/app/shared/pipes/sentence-case.pipe';
 import { SnakeCaseToSpaceCasePipe } from 'src/app/shared/pipes/snake-case-to-space-case.pipe';
@@ -34,27 +35,59 @@ export class IntacctMappingComponent implements OnInit {
 
   constructor(
     private router: Router,
-    private mappingService: SiMappingsService
+    private mappingService: SiMappingsService,
+    private commonResourcesService: CommonResourcesService
   ) { }
 
   private setupPages(): void {
+
+    if (!brandingFeatureConfig.featureFlags.mapEmployees) {
+      this.mappingPages.splice(0, 1);
+    }
+    this.router.navigateByUrl(this.mappingPages[0].routerLink);
+
     this.mappingService.getMappingSettings().subscribe((response) => {
       if (response.results && Array.isArray(response.results)) {
-        response.results.forEach((item) => {
-          if (item.source_field !== FyleField.EMPLOYEE && item.source_field !== FyleField.CATEGORY) {
-            const mappingPage = new SnakeCaseToSpaceCasePipe().transform(item.source_field);
-            this.mappingPages.push({
-              label: brandingFeatureConfig.featureFlags.exportSettings.transformContentToSentenceCase ? new SentenceCasePipe().transform(mappingPage) : new TitleCasePipe().transform(mappingPage),
-              routerLink: `/integrations/intacct/main/mapping/${encodeURIComponent(item.source_field.toLowerCase())}`
-            });
-          }
+
+        // Show display names only for projects and cost centers
+        const attributeTypes = response.results
+          .map((item) => item.source_field)
+          .filter(fieldType => fieldType === FyleField.PROJECT || fieldType === FyleField.COST_CENTER);
+
+        this.commonResourcesService.getDimensionDetails({sourceType: 'FYLE', attributeTypes}).subscribe((dimensionDetails) => {
+          /**
+           * For every mapping
+           * 1. Get the source_field
+           * 2. Check if the source_field has a display name in dimension details
+           *   - If it does, use the display name
+           *   - If it doesn't, use the source_field (space cased and sentence cased)
+           */
+          response.results.forEach((item) => {
+            if (item.source_field !== FyleField.EMPLOYEE && item.source_field !== FyleField.CATEGORY) {
+              const mappingPage = new SnakeCaseToSpaceCasePipe().transform(item.source_field);
+
+              const displayName = dimensionDetails.results.find((detail) => detail.attribute_type === item.source_field)?.display_name;
+
+              let label;
+              if (displayName) {
+                label = displayName;
+              } else if (brandingFeatureConfig.featureFlags.exportSettings.transformContentToSentenceCase) {
+                label = new SentenceCasePipe().transform(mappingPage);
+              } else {
+                label = new TitleCasePipe().transform(mappingPage);
+              }
+
+              this.mappingPages.push({
+                label,
+                routerLink: `/integrations/intacct/main/mapping/${encodeURIComponent(item.source_field.toLowerCase())}`
+              });
+            }
+          });
+          this.isLoading = false;
         });
+      } else {
+        this.isLoading = false;
       }
-      if (!brandingFeatureConfig.featureFlags.mapEmployees) {
-        this.mappingPages.splice(0, 1);
-      }
-      this.router.navigateByUrl(this.mappingPages[0].routerLink);
-      this.isLoading = false;
     });
   }
 


### PR DESCRIPTION
### Description
Show custom display names for the "Project" and "Cost Center" Fyle fields in the intacct mapping page <img width="910" alt="image" src="https://github.com/user-attachments/assets/784fc823-93e2-4c8e-acd3-01dbfa39fdf5" />


## Clickup
https://app.clickup.com/t/86cybaer4