### PR TITLE
feat: bamboo HR token health check.

### DIFF
--- a/src/app/core/services/bamboo-hr/bamboo-hr.service.ts
+++ b/src/app/core/services/bamboo-hr/bamboo-hr.service.ts
@@ -49,4 +49,9 @@ export class BambooHrService {
   syncEmployees(): Observable<{}> {
     return this.apiService.post(`/orgs/${this.orgId}/bamboohr/refresh_employees/`, {});
   }
+
+  checkHealth(): Observable<{}> {
+    return this.apiService.get(`/orgs/${this.orgId}/bamboohr/health_check/`, {});
+  }
+
 }

--- a/src/app/integrations/bamboo-hr/bamboo-hr.component.ts
+++ b/src/app/integrations/bamboo-hr/bamboo-hr.component.ts
@@ -153,6 +153,7 @@ export class BambooHrComponent implements OnInit {
 
   private setupPage(): void {
     this.helperService.setBaseApiURL(AppUrl.BAMBOO_HR);
+    this.checkTokenHealth();
     this.bambooHrService.getBambooHRData().subscribe((bambooHrData: BambooHr) => {
       this.isBambooConnected = bambooHrData.sub_domain && bambooHrData.api_token ? true : false;
       this.bambooHrData = bambooHrData;
@@ -160,6 +161,22 @@ export class BambooHrComponent implements OnInit {
     }, () => {
       this.isBambooConnected = false;
       this.getBambooHrConfiguration();
+    });
+  }
+
+  tokenExpiredBambooHr(): void {
+    this.isLoading = true;
+    this.bambooHrService.disconnectBambooHr().subscribe(() => {
+      this.displayToastMessage(ToastSeverity.ERROR, 'Session expired on BambooHR! Please connect again to continue.');
+      this.isBambooConnected = false;
+      this.isLoading = false;
+    });
+  }
+
+  private checkTokenHealth(): void{
+    this.bambooHrService.checkHealth().subscribe((data) => {
+    }, () => {
+      this.tokenExpiredBambooHr();
     });
   }
 

--- a/src/app/integrations/bamboo-hr/bamboo-hr.component.ts
+++ b/src/app/integrations/bamboo-hr/bamboo-hr.component.ts
@@ -23,8 +23,6 @@ export class BambooHrComponent implements OnInit {
 
   isBambooConnected: boolean;
 
-  isBambooTokenExpired: boolean;
-
   isBambooConnectionInProgress: boolean;
 
   isBambooSetupInProgress: boolean;
@@ -158,16 +156,16 @@ export class BambooHrComponent implements OnInit {
     this.checkTokenHealth();
   }
 
-  private loadBambooHR(): void {
+  private loadBambooHR(isBambooTokenExpired: boolean): void {
     this.bambooHrService.getBambooHRData().subscribe((bambooHrData: BambooHr) => {
       this.isBambooConnected = bambooHrData.sub_domain && bambooHrData.api_token ? true : false;
       this.getBambooHrConfiguration();
 
-      if (this.isBambooConnected && this.isBambooTokenExpired === false){
+      if (this.isBambooConnected && isBambooTokenExpired === false){
         this.bambooHrData = bambooHrData;
       } else if (this.isBambooConnected) {
         this.isBambooConnected = false;
-        this.displayToastMessage(ToastSeverity.ERROR, 'Session expired on BambooHR, Please connect again to continue..!', 6000);
+        this.displayToastMessage(ToastSeverity.ERROR, 'Token expired on BambooHR, Please connect again to continue..!', 6000);
       }
 
     }, () => {
@@ -178,11 +176,9 @@ export class BambooHrComponent implements OnInit {
 
   private checkTokenHealth(): void{
     this.bambooHrService.checkHealth().subscribe(() => {
-      this.isBambooTokenExpired = false;
-      this.loadBambooHR();
+      this.loadBambooHR(false);
     }, () => {
-      this.isBambooTokenExpired = true;
-      this.loadBambooHR();
+      this.loadBambooHR(true);
     });
   }
 

--- a/src/app/integrations/bamboo-hr/bamboo-hr.component.ts
+++ b/src/app/integrations/bamboo-hr/bamboo-hr.component.ts
@@ -163,9 +163,9 @@ export class BambooHrComponent implements OnInit {
       this.isBambooConnected = bambooHrData.sub_domain && bambooHrData.api_token ? true : false;
       this.getBambooHrConfiguration();
 
-      if(this.isBambooConnected && this.isBombooTokenExpired == false){
+      if (this.isBambooConnected && this.isBombooTokenExpired === false){
         this.bambooHrData = bambooHrData;
-      } else if(this.isBambooConnected) {
+      } else if (this.isBambooConnected) {
         this.isBambooConnected = false;
         this.displayToastMessage(ToastSeverity.ERROR, 'Session expired on BambooHR, Please connect again to continue..!', 6000);
       }

--- a/src/app/integrations/bamboo-hr/bamboo-hr.component.ts
+++ b/src/app/integrations/bamboo-hr/bamboo-hr.component.ts
@@ -23,7 +23,7 @@ export class BambooHrComponent implements OnInit {
 
   isBambooConnected: boolean;
 
-  isBombooTokenExpired: boolean;
+  isBambooTokenExpired: boolean;
 
   isBambooConnectionInProgress: boolean;
 
@@ -163,7 +163,7 @@ export class BambooHrComponent implements OnInit {
       this.isBambooConnected = bambooHrData.sub_domain && bambooHrData.api_token ? true : false;
       this.getBambooHrConfiguration();
 
-      if (this.isBambooConnected && this.isBombooTokenExpired === false){
+      if (this.isBambooConnected && this.isBambooTokenExpired === false){
         this.bambooHrData = bambooHrData;
       } else if (this.isBambooConnected) {
         this.isBambooConnected = false;
@@ -178,10 +178,10 @@ export class BambooHrComponent implements OnInit {
 
   private checkTokenHealth(): void{
     this.bambooHrService.checkHealth().subscribe(() => {
-      this.isBombooTokenExpired = false;
+      this.isBambooTokenExpired = false;
       this.loadBambooHR();
     }, () => {
-      this.isBombooTokenExpired = true;
+      this.isBambooTokenExpired = true;
       this.loadBambooHR();
     });
   }


### PR DESCRIPTION
### Description
If the bamboo API token is expired, and the user is on bamboo page the user will get notified as bamboo token is expired and the user need to reconnect the bamboo API to access the bamboo.

## Clickup
https://app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the BambooHR integration with an automated session health check. The system now verifies token validity during page setup. If a session token is found expired, the integration is disconnected and an error message is displayed to inform the user.
  - Added a new method to check the health status of the BambooHR integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->