### PR TITLE
feat: support standalone cost code imports in intacct import settings

### DIFF
--- a/src/app/core/models/intacct/intacct-configuration/import-settings.model.ts
+++ b/src/app/core/models/intacct/intacct-configuration/import-settings.model.ts
@@ -80,8 +80,8 @@ export class ImportSettings {
                 is_import_enabled: importSettingsForm.get('isDependentImportEnabled')?.value,
                 cost_code_field_name: importSettingsForm.get('costCodes')?.value?.attribute_type,
                 cost_code_placeholder: importSettingsForm.get('costCodes')?.value?.source_placeholder,
-                cost_type_field_name: importSettingsForm.get('costTypes')?.value?.attribute_type,
-                cost_type_placeholder: importSettingsForm.get('costTypes')?.value?.source_placeholder,
+                cost_type_field_name: importSettingsForm.get('costTypes')?.value?.attribute_type ?? null,
+                cost_type_placeholder: importSettingsForm.get('costTypes')?.value?.source_placeholder ?? null,
                 workspace: importSettingsForm.get('workspaceId')?.value
             };
         }

--- a/src/app/core/models/intacct/intacct-configuration/import-settings.model.ts
+++ b/src/app/core/models/intacct/intacct-configuration/import-settings.model.ts
@@ -77,9 +77,11 @@ export class ImportSettings {
 
         let dependentFieldSetting = null;
         if (existingDependentFieldSettings || importSettingsForm.get('isDependentImportEnabled')?.value) {
+            // Cost types are disabled by setting cost_type_field_name to null
+            // We support disabling cost types, but not cost codes
             let cost_type_field_name = null;
             let cost_type_placeholder = null;
-            const is_cost_type_import_enabled = importSettingsForm.get('costTypeImportToggle')?.value;
+            const is_cost_type_import_enabled = importSettingsForm.get('costTypesImportToggle')?.value;
             if (is_cost_type_import_enabled) {
                 cost_type_field_name = importSettingsForm.get('costTypes')?.value?.attribute_type ?? null;
                 cost_type_placeholder = importSettingsForm.get('costTypes')?.value?.source_placeholder ?? null;

--- a/src/app/core/models/intacct/intacct-configuration/import-settings.model.ts
+++ b/src/app/core/models/intacct/intacct-configuration/import-settings.model.ts
@@ -31,6 +31,7 @@ export type DependentFieldSetting = {
     cost_code_placeholder: string,
     cost_type_field_name: string,
     cost_type_placeholder: string,
+    is_cost_type_import_enabled: boolean,
     workspace: number
   };
 
@@ -76,12 +77,20 @@ export class ImportSettings {
 
         let dependentFieldSetting = null;
         if (existingDependentFieldSettings || importSettingsForm.get('isDependentImportEnabled')?.value) {
+            let cost_type_field_name = null;
+            let cost_type_placeholder = null;
+            const is_cost_type_import_enabled = importSettingsForm.get('costTypeImportToggle')?.value;
+            if (is_cost_type_import_enabled) {
+                cost_type_field_name = importSettingsForm.get('costTypes')?.value?.attribute_type ?? null;
+                cost_type_placeholder = importSettingsForm.get('costTypes')?.value?.source_placeholder ?? null;
+            }
             dependentFieldSetting = {
                 is_import_enabled: importSettingsForm.get('isDependentImportEnabled')?.value,
                 cost_code_field_name: importSettingsForm.get('costCodes')?.value?.attribute_type,
                 cost_code_placeholder: importSettingsForm.get('costCodes')?.value?.source_placeholder,
-                cost_type_field_name: importSettingsForm.get('costTypes')?.value?.attribute_type ?? null,
-                cost_type_placeholder: importSettingsForm.get('costTypes')?.value?.source_placeholder ?? null,
+                cost_type_field_name,
+                cost_type_placeholder,
+                is_cost_type_import_enabled,
                 workspace: importSettingsForm.get('workspaceId')?.value
             };
         }

--- a/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.html
+++ b/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.html
@@ -18,9 +18,9 @@
                         [appName]="appName"
                         [accountingFieldOptions]="sageIntacctFields"
                         [fyleFieldOptions]="fyleFields"
-                        [costCategoryOption]="costCategoryOption" 
-                        [costCodeFieldOption]="costCodeFieldOption" 
-                        [dependentImportFields]="dependentImportFields" 
+                        [costCategoryOption]="costCategoryOption"
+                        [costCodeFieldOption]="costCodeFieldOption"
+                        [dependentImportFields]="dependentImportFields"
                         [dependentDestinationValue]="'PROJECT'"
                         [isDestinationFixedImport]="true"
                         (showWarningForDependentFields)="showWarningForDependentFields()">
@@ -46,11 +46,11 @@
     </div>
 </div>
 <div>
-    <app-configuration-confirmation-dialog 
+    <app-configuration-confirmation-dialog
         (warningAccepted)="acceptDependentFieldWarning($event)"
-        [isWarningVisible]="showDependentFieldWarning" 
+        [isWarningVisible]="showDependentFieldWarning"
         [headerText]="'Warning'"
-        [contextText]="'You have imported Cost codes and Cost Types from Sage Intacct by mapping them to fields in ' + brandingConfig.brandName + '. By turning off the import, you would lose the mappings you\'ve established for these fields.'"
+        [contextText]="'You have imported Cost codes' + (importSettings?.dependent_field_settings?.cost_type_field_name ? ' and Cost Types' : '') + ' from Sage Intacct by mapping them to fields in ' + brandingConfig.brandName + '. By turning off the import, you would lose the mappings you\'ve established for these fields.'"
         [confirmBtnText]="'Continue'">
     </app-configuration-confirmation-dialog>
 </div>

--- a/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.html
+++ b/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.html
@@ -50,7 +50,7 @@
         (warningAccepted)="acceptDependentFieldWarning($event)"
         [isWarningVisible]="showDependentFieldWarning"
         [headerText]="'Warning'"
-        [contextText]="'You have imported Cost codes' + (importSettings?.dependent_field_settings?.cost_type_field_name ? ' and Cost Types' : '') + ' from Sage Intacct by mapping them to fields in ' + brandingConfig.brandName + '. By turning off the import, you would lose the mappings you\'ve established for these fields.'"
+        [contextText]="'You have imported Cost codes' + (importSettings?.dependent_field_settings?.cost_type_field_name ? ' and cost types' : '') + ' from Sage Intacct by mapping them to fields in ' + brandingConfig.brandName + '. By turning off the import, you would lose the mappings you\'ve established for these fields.'"
         [confirmBtnText]="'Continue'">
     </app-configuration-confirmation-dialog>
 </div>

--- a/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.spec.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.spec.ts
@@ -144,9 +144,10 @@ describe('IntacctC1ImportSettingsComponent', () => {
       expect(component.importSettingsForm.get('importCategories')).toBeDefined();
       expect(component.importSettingsForm.get('importTaxCodes')).toBeDefined();
       expect(component.importSettingsForm.get('costCodes')).toBeDefined();
-      expect(component.importSettingsForm.get('dependentFieldImportToggle')).toBeDefined();
+      expect(component.importSettingsForm.get('costCodesImportToggle')).toBeDefined();
       expect(component.importSettingsForm.get('workspaceId')).toBeDefined();
       expect(component.importSettingsForm.get('costTypes')).toBeDefined();
+      expect(component.importSettingsForm.get('costTypesImportToggle')).toBeDefined();
       expect(component.importSettingsForm.get('isDependentImportEnabled')).toBeDefined();
       expect(component.importSettingsForm.get('sageIntacctTaxCodes')).toBeDefined();
       expect(component.importSettingsForm.get('expenseFields')).toBeDefined();
@@ -263,23 +264,7 @@ describe('IntacctC1ImportSettingsComponent', () => {
       it('should handle isDependentImportEnabled being set', () => {
         component.importSettingsForm.get('isDependentImportEnabled')?.setValue(true);
 
-        expect(helperService.enableFormField).toHaveBeenCalledWith(component.importSettingsForm, 'costCodes');
-        expect(helperService.enableFormField).toHaveBeenCalledWith(component.importSettingsForm, 'costTypes');
         expect(helperService.markControllerAsRequired).toHaveBeenCalledWith(component.importSettingsForm, 'costCodes');
-        expect(helperService.markControllerAsRequired).toHaveBeenCalledWith(component.importSettingsForm, 'costTypes');
-        expect(component.dependentImportFields[0].isDisabled).toBeFalse();
-        expect(component.dependentImportFields[1].isDisabled).toBeFalse();
-      });
-
-      it('should handle isDependentImportEnabled being unset', () => {
-        component.importSettingsForm.get('isDependentImportEnabled')?.setValue(false);
-
-        expect(helperService.disableFormField).toHaveBeenCalledWith(component.importSettingsForm, 'costCodes');
-        expect(helperService.disableFormField).toHaveBeenCalledWith(component.importSettingsForm, 'costTypes');
-        expect(helperService.clearValidatorAndResetValue).toHaveBeenCalledWith(component.importSettingsForm, 'costCodes');
-        expect(helperService.clearValidatorAndResetValue).toHaveBeenCalledWith(component.importSettingsForm, 'costTypes');
-        expect(component.dependentImportFields[0].isDisabled).toBeTrue();
-        expect(component.dependentImportFields[1].isDisabled).toBeTrue();
       });
     });
 
@@ -310,7 +295,6 @@ describe('IntacctC1ImportSettingsComponent', () => {
 
       it('should handle non-custom field selection', () => {
         component.importSettingsForm.controls.costCodes.setValue({ attribute_type: 'some_field' });
-        expect(component.dependentImportFields[0].isDisabled).toBeTrue();
       });
     });
 

--- a/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.ts
@@ -212,6 +212,7 @@ export class IntacctC1ImportSettingsComponent implements OnInit {
   private dependentCostFieldsWatchers(formControllerName: string): void {
     this.importSettingsForm.controls[formControllerName].valueChanges.subscribe((value) => {
       if (value?.attribute_type === 'custom_field') {
+        // Show a dialog when the "Create a Custom Field" button is clicked
         this.addCustomField();
         this.customFieldType = formControllerName;
         this.customFieldControl = this.importSettingsForm.controls[formControllerName];
@@ -220,37 +221,39 @@ export class IntacctC1ImportSettingsComponent implements OnInit {
             source_field: null
           });
         }
-      } else if (value) {
-        this.dependentImportFields.forEach((fields, index) => {
-          if (fields.formController === formControllerName) {
-            this.dependentImportFields[index].isDisabled = true;
-          }
-        });
+      } else if (value?.attribute_type && formControllerName === 'costCodes') {
+        // Once the cost codes dialog is submitted and the field value is set,
+        // 1. disable cost codes
+        // 2. enable cost types
+        this.importSettingsForm.get('costCodesImportToggle')?.setValue(true);
+        this.importSettingsForm.get('costCodesImportToggle')?.disable();
+
+        this.importSettingsForm.get('costTypes')?.enable();
+        this.importSettingsForm.get('costTypesImportToggle')?.enable();
       }
     });
   }
 
   private dependentFieldWatchers(): void {
-    if (this.importSettingsForm.get('isDependentImportEnabled')?.value) {
+    if (this.importSettingsForm.get('costCodes')?.value) {
       this.helper.disableFormField(this.importSettingsForm, 'costCodes');
+      this.helper.disableFormField(this.importSettingsForm, 'costCodesImportToggle');
+    } else {
+      // Cost types cannot be edited without first mapping cost codes
       this.helper.disableFormField(this.importSettingsForm, 'costTypes');
+      this.helper.disableFormField(this.importSettingsForm, 'costTypesImportToggle');
+      this.helper.disableFormField(this.importSettingsForm, 'costTypesImportToggle');
+    }
+
+    if (this.importSettingsForm.get('costTypes')?.value) {
+      this.importSettingsForm.controls.costTypes.disable();
     }
 
     this.importSettingsForm.controls.isDependentImportEnabled.valueChanges.subscribe((isDependentImportEnabled) => {
       if (isDependentImportEnabled) {
-        this.helper.enableFormField(this.importSettingsForm, 'costCodes');
-        this.helper.enableFormField(this.importSettingsForm, 'costTypes');
         this.helper.markControllerAsRequired(this.importSettingsForm, 'costCodes');
-        this.helper.markControllerAsRequired(this.importSettingsForm, 'costTypes');
-        this.dependentImportFields[0].isDisabled = false;
-        this.dependentImportFields[1].isDisabled = false;
       } else {
-        this.helper.disableFormField(this.importSettingsForm, 'costCodes');
-        this.helper.disableFormField(this.importSettingsForm, 'costTypes');
-        this.helper.clearValidatorAndResetValue(this.importSettingsForm, 'costCodes');
-        this.helper.clearValidatorAndResetValue(this.importSettingsForm, 'costTypes');
-        this.dependentImportFields[0].isDisabled = true;
-        this.dependentImportFields[1].isDisabled = true;
+        this.importSettingsForm?.get('costCodes')?.clearValidators();
       }
     });
 
@@ -435,9 +438,11 @@ export class IntacctC1ImportSettingsComponent implements OnInit {
       importCategories: [importSettings.configurations.import_categories || null],
       importTaxCodes: [importSettings.configurations.import_tax_codes || false],
       costCodes: [importSettings.dependent_field_settings?.cost_code_field_name ? this.dependentFieldFormValue(importSettings.dependent_field_settings.cost_code_field_name, importSettings.dependent_field_settings.cost_code_placeholder, 'costCodes') : null],
-      dependentFieldImportToggle: [true],
+      costCodesImportToggle: [true],
+      sImportToggle: [true],
       workspaceId: this.storageService.get('workspaceId'),
       costTypes: [importSettings.dependent_field_settings?.cost_type_field_name ? this.dependentFieldFormValue(importSettings.dependent_field_settings.cost_type_field_name, importSettings.dependent_field_settings.cost_type_placeholder, 'costTypes') : null],
+      costTypesImportToggle: [!!importSettings.dependent_field_settings?.is_cost_type_import_enabled],
       isDependentImportEnabled: [importSettings.dependent_field_settings?.is_import_enabled || false],
       sageIntacctTaxCodes: [importSettings.general_mappings.default_tax_code.id || null],
       expenseFields: this.formBuilder.array(this.constructFormArray()),
@@ -494,7 +499,7 @@ export class IntacctC1ImportSettingsComponent implements OnInit {
 
   save(): void {
     this.saveInProgress = true;
-    const importSettingPayload = ImportSettings.constructPayload(this.importSettingsForm, null);
+    const importSettingPayload = ImportSettings.constructPayload(this.importSettingsForm, this.importSettings.dependent_field_settings);
     this.importSettingService.postImportSettings(importSettingPayload).subscribe((response: ImportSettingPost) => {
       this.toastService.displayToastMessage(ToastSeverity.SUCCESS, 'Import settings saved successfully');
       this.trackingService.trackTimeSpent(TrackingApp.INTACCT, Page.IMPORT_SETTINGS_INTACCT, this.sessionStartTime);

--- a/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.html
+++ b/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.html
@@ -162,7 +162,7 @@
                                     </div>
                                 </ng-template>
                             </p-dropdown>
-                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costCodeImportToggle" [disabled]="true"></p-inputSwitch>
+                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costCodesImportToggle" [disabled]="true"></p-inputSwitch>
                         </div>
                         <div class="tw-flex tw-pt-4" *ngIf="importSettingsForm.get('isDependentImportEnabled')?.value">
                             <div>
@@ -180,7 +180,7 @@
                                         {{ option.display_name }}                                    </div>
                                   </ng-template>
                             </p-dropdown>
-                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costTypeImportToggle" [disabled]="true"></p-inputSwitch>
+                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costTypesImportToggle" [disabled]="true"></p-inputSwitch>
                         </div>
                     </div>
                 </div>

--- a/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.html
+++ b/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.html
@@ -3,7 +3,7 @@
 </div>
 <div *ngIf="!isLoading" class="configuration--contents tw-border-separator tw-mt-6" [ngClass]="brandingStyle.common.configurationContents">
     <div>
-        <app-configuration-step-header 
+        <app-configuration-step-header
         [headerText]="'Import Settings'"
         [contentText]="'In this section, you can choose the fields required to be imported from Sage Intacct to ' + brandingConfig.brandName + '.'"
         [redirectLink]="redirectLink"
@@ -124,12 +124,12 @@
                                     </div>
                                     </ng-template>
                                     <ng-template pTemplate="selectedItem" let-item class="tw-flex tw-justify-between tw-items-center">
-                                    
+
                                         <div>
                                             {{ item.display_name }}
                                         </div>
                                         <app-svg-icon [svgSource]="'cross-medium'" (click)="removeFilter(expenseField)" [height]="'16px'" [width]="'16px'"></app-svg-icon>
-                                    
+
                                     </ng-template>
                               </p-dropdown>
                               <p *ngIf="expenseField.value.source_field && !expenseField.valid && !hasDuplicateOption(expenseField, i, 'source_field') || (!expenseField.value.source_field && expenseField.value.import_to_fyle)" class="tw-text-alert-toast tw-text-12-px tw-pt-4-px tw-pl-14-px">
@@ -143,7 +143,7 @@
                             <div>
                                 <input formControlName="isDependentImportEnabled" type="checkbox"/>
                             </div>
-                            <label class="tw-pl-2 tw-text-14-px" for="checkbox">Import Cost Code and Cost Type from Sage Intacct as dependent fields</label>
+                            <label class="tw-pl-2 tw-text-14-px" for="checkbox">Import Cost Code and/or Cost Type from Sage Intacct as dependent fields</label>
                         </div>
                         <div class="tw-flex tw-pt-4" *ngIf="importSettingsForm.get('isDependentImportEnabled')?.value">
                             <div>
@@ -162,7 +162,7 @@
                                     </div>
                                 </ng-template>
                             </p-dropdown>
-                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="dependentFieldImportToggle" [disabled]="true"></p-inputSwitch>
+                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costCodeImportToggle" [disabled]="true"></p-inputSwitch>
                         </div>
                         <div class="tw-flex tw-pt-4" *ngIf="importSettingsForm.get('isDependentImportEnabled')?.value">
                             <div>
@@ -180,13 +180,13 @@
                                         {{ option.display_name }}                                    </div>
                                   </ng-template>
                             </p-dropdown>
-                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="dependentFieldImportToggle" [disabled]="true"></p-inputSwitch>
+                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costTypeImportToggle" [disabled]="true"></p-inputSwitch>
                         </div>
-                    </div>                      
+                    </div>
                 </div>
                 <div class="tw-text-alert-toast tw-pt-4 tw-pl-14-px" *ngIf="importSettingsForm.get('expenseFields')?.hasError('duplicateFyleFields') || importSettingsForm.get('expenseFields')?.hasError('duplicateSageIntacctFields')">
                     *{{brandingConfig.brandName}} and Sage Intacct Fields should be unique.
-                  </div>                  
+                  </div>
             </div>
             <div *ngIf="showAddButton" class="add-button-container tw-pl-36-px">
                 <app-svg-icon [svgSource]="'plus-square-medium'" [width]="'18px'" [height]="'18px'" [styleClasses]="'tw-cursor-pointer tw-text-mandatory-field-color'" (iconClick)="addExpenseField()"></app-svg-icon>
@@ -237,7 +237,7 @@
             </div>
         </div>
 
-        <app-configuration-step-footer [ctaText] = "!saveInProgress ? (isOnboarding ? ConfigurationCtaText.SAVE_AND_CONTINUE : ConfigurationCtaText.SAVE) : ConfigurationCtaText.SAVING" (save)="save()" [isButtonDisabled]="!importSettingsForm.valid"></app-configuration-step-footer>    
+        <app-configuration-step-footer [ctaText] = "!saveInProgress ? (isOnboarding ? ConfigurationCtaText.SAVE_AND_CONTINUE : ConfigurationCtaText.SAVE) : ConfigurationCtaText.SAVING" (save)="save()" [isButtonDisabled]="!importSettingsForm.valid"></app-configuration-step-footer>
     </form>
 </div>
 
@@ -292,8 +292,8 @@
                     [placeholder]="customFieldForm.get('source_placeholder')?.value ? customFieldForm.get('source_placeholder')?.value : 'Enter Text'">
                   </div>
                 </div>
-              </div>              
-            
+              </div>
+
             <div class="tw-flex tw-justify-end tw-pt-24-px tw-text-14-px">
                 <button type="button" class="cancel-btn" (click)="closeModel()">
                     Cancel
@@ -320,7 +320,7 @@
     </div>
     <div class="tw-pl-24-px tw-pr-10-px tw-pt-16-px tw-pb-24-px">
         <div class="tw-text-14-px tw-font-400 tw-text-slightly-normal-text-color">
-            You have imported Cost codes and Cost Types from Sage Intacct by mapping them to fields in {{brandingConfig.brandName}}. By turning off the import, you would lose the mappings you've established for these fields.
+            You have imported Cost codes{{ dependentFieldSettings?.cost_type_field_name ? ' and Cost Types' : '' }} from Sage Intacct by mapping them to fields in {{brandingConfig.brandName}}. By turning off the import, you would lose the mappings you've established for these fields.
         </div>
         <div class="tw-pt-26-px tw-text-14-px tw-font-400 tw-text-slightly-normal-text-color">
             Are you sure you want to continue?

--- a/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.spec.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.spec.ts
@@ -347,18 +347,16 @@ describe('IntacctImportSettingsComponent', () => {
         });
 
         expect(costCodesControl?.enabled).toBeTrue();
-        expect(costTypesControl?.enabled).toBeTrue();
+        expect(costTypesControl?.enabled).toBeFalse();
         expect(costCodesControl?.hasValidator(Validators.required)).toBeTrue();
-        expect(costTypesControl?.hasValidator(Validators.required)).toBeTrue();
 
         component.importSettingsForm.patchValue({
           isDependentImportEnabled: false
         });
 
-        expect(costCodesControl?.enabled).toBeFalse();
+        expect(costCodesControl?.enabled).toBeTrue();
         expect(costTypesControl?.enabled).toBeFalse();
         expect(costCodesControl?.hasValidator(Validators.required)).toBeFalse();
-        expect(costTypesControl?.hasValidator(Validators.required)).toBeFalse();
       });
 
       it('should handle custom field selection for cost codes', () => {

--- a/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.spec.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.spec.ts
@@ -147,7 +147,8 @@ describe('IntacctImportSettingsComponent', () => {
         expect(component.importSettingsForm.get('importCategories')).toBeTruthy();
         expect(component.importSettingsForm.get('importTaxCodes')).toBeTruthy();
         expect(component.importSettingsForm.get('costCodes')).toBeTruthy();
-        expect(component.importSettingsForm.get('dependentFieldImportToggle')).toBeTruthy();
+        expect(component.importSettingsForm.get('costCodeImportToggle')).toBeTruthy();
+        expect(component.importSettingsForm.get('costTypeImportToggle')).toBeTruthy();
         expect(component.importSettingsForm.get('workspaceId')).toBeTruthy();
         expect(component.importSettingsForm.get('costTypes')).toBeTruthy();
         expect(component.importSettingsForm.get('isDependentImportEnabled')).toBeTruthy();

--- a/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.spec.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.spec.ts
@@ -147,8 +147,8 @@ describe('IntacctImportSettingsComponent', () => {
         expect(component.importSettingsForm.get('importCategories')).toBeTruthy();
         expect(component.importSettingsForm.get('importTaxCodes')).toBeTruthy();
         expect(component.importSettingsForm.get('costCodes')).toBeTruthy();
-        expect(component.importSettingsForm.get('costCodeImportToggle')).toBeTruthy();
-        expect(component.importSettingsForm.get('costTypeImportToggle')).toBeTruthy();
+        expect(component.importSettingsForm.get('costCodesImportToggle')).toBeTruthy();
+        expect(component.importSettingsForm.get('costTypesImportToggle')).toBeTruthy();
         expect(component.importSettingsForm.get('workspaceId')).toBeTruthy();
         expect(component.importSettingsForm.get('costTypes')).toBeTruthy();
         expect(component.importSettingsForm.get('isDependentImportEnabled')).toBeTruthy();

--- a/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.ts
@@ -328,12 +328,12 @@ export class IntacctImportSettingsComponent implements OnInit {
     if (this.importSettingsForm.get('costCodes')?.value) {
       this.costCodeFieldOption = [this.importSettingsForm.get('costCodes')?.value];
       this.importSettingsForm.controls.costCodes.disable();
-      this.importSettingsForm.get('costCodeImportToggle')?.disable();
+      this.importSettingsForm.get('costCodesImportToggle')?.disable();
     } else {
       // Cost types cannot be edited without first mapping cost codes
       this.importSettingsForm.get('costTypes')?.disable();
-      this.importSettingsForm.get('costTypeImportToggle')?.disable();
-      this.importSettingsForm.get('costTypeImportToggle')?.setValue(false);
+      this.importSettingsForm.get('costTypesImportToggle')?.disable();
+      this.importSettingsForm.get('costTypesImportToggle')?.setValue(false);
     }
 
     if (this.importSettingsForm.get('costTypes')?.value) {
@@ -365,11 +365,11 @@ export class IntacctImportSettingsComponent implements OnInit {
         // Once the dialog is submitted and the field value is set,
         // 1. disable cost codes
         // 2. enable cost types
-        this.importSettingsForm.get('costCodeImportToggle')?.setValue(true);
-        this.importSettingsForm.get('costCodeImportToggle')?.disable();
+        this.importSettingsForm.get('costCodesImportToggle')?.setValue(true);
+        this.importSettingsForm.get('costCodesImportToggle')?.disable();
 
         this.importSettingsForm.get('costTypes')?.enable();
-        this.importSettingsForm.get('costTypeImportToggle')?.enable();
+        this.importSettingsForm.get('costTypesImportToggle')?.enable();
       }
     });
 
@@ -541,8 +541,8 @@ export class IntacctImportSettingsComponent implements OnInit {
       importCategories: [importSettings.configurations.import_categories || null],
       importTaxCodes: [importSettings.configurations.import_tax_codes || null],
       costCodes: [importSettings.dependent_field_settings?.cost_code_field_name ? this.generateDependentFieldValue(importSettings.dependent_field_settings.cost_code_field_name, importSettings.dependent_field_settings.cost_code_placeholder) : null],
-      costCodeImportToggle: [true],
-      costTypeImportToggle: [!!importSettings.dependent_field_settings?.is_cost_type_import_enabled],
+      costCodesImportToggle: [true],
+      costTypesImportToggle: [!!importSettings.dependent_field_settings?.is_cost_type_import_enabled],
       workspaceId: this.storageService.get('workspaceId'),
       costTypes: [importSettings.dependent_field_settings?.cost_type_field_name ? this.generateDependentFieldValue(importSettings.dependent_field_settings.cost_type_field_name, importSettings.dependent_field_settings.cost_type_placeholder!) : null],
       isDependentImportEnabled: [importSettings.dependent_field_settings?.is_import_enabled || false],

--- a/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.ts
@@ -339,7 +339,6 @@ export class IntacctImportSettingsComponent implements OnInit {
     if (this.importSettingsForm.get('costTypes')?.value) {
       this.costTypeFieldOption = [this.importSettingsForm.get('costTypes')?.value];
       this.importSettingsForm.controls.costTypes.disable();
-      this.importSettingsForm.get('costTypeImportToggle')?.disable();
     }
 
     this.importSettingsForm.controls.isDependentImportEnabled.valueChanges.subscribe((isDependentImportEnabled) => {
@@ -386,10 +385,6 @@ export class IntacctImportSettingsComponent implements OnInit {
               source_field: null
             });
         }
-      } else if (value) {
-        // Once the dialog is submitted and the field value is set, disable the field
-        this.importSettingsForm.get('costTypeImportToggle')?.setValue(true);
-        this.importSettingsForm.get('costTypeImportToggle')?.disable();
       }
     });
   }
@@ -547,9 +542,9 @@ export class IntacctImportSettingsComponent implements OnInit {
       importTaxCodes: [importSettings.configurations.import_tax_codes || null],
       costCodes: [importSettings.dependent_field_settings?.cost_code_field_name ? this.generateDependentFieldValue(importSettings.dependent_field_settings.cost_code_field_name, importSettings.dependent_field_settings.cost_code_placeholder) : null],
       costCodeImportToggle: [true],
-      costTypeImportToggle: [!!importSettings.dependent_field_settings?.cost_type_field_name],
+      costTypeImportToggle: [!!importSettings.dependent_field_settings?.is_cost_type_import_enabled],
       workspaceId: this.storageService.get('workspaceId'),
-      costTypes: [importSettings.dependent_field_settings?.cost_type_field_name ? this.generateDependentFieldValue(importSettings.dependent_field_settings.cost_type_field_name, importSettings.dependent_field_settings.cost_type_placeholder) : null],
+      costTypes: [importSettings.dependent_field_settings?.cost_type_field_name ? this.generateDependentFieldValue(importSettings.dependent_field_settings.cost_type_field_name, importSettings.dependent_field_settings.cost_type_placeholder!) : null],
       isDependentImportEnabled: [importSettings.dependent_field_settings?.is_import_enabled || false],
       sageIntacctTaxCodes: [(this.sageIntacctTaxGroup?.find(taxGroup => taxGroup.destination_id === this.importSettings?.general_mappings?.default_tax_code?.id)) || null, importSettings.configurations.import_tax_codes ? [Validators.required] : []],
       expenseFields: this.formBuilder.array(this.constructFormArray()),

--- a/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.html
+++ b/src/app/shared/components/configuration/configuration-import-field/configuration-import-field.component.html
@@ -42,9 +42,9 @@
                             <app-optional-field *ngIf="!isAsterikAllowed"></app-optional-field>
                         </h4>
                         <h5 *ngIf="!isCloneSettingView" class="!tw-text-text-muted tw-text-14-px !tw-font-400 !tw-leading-4" [ngClass]="brandingStyle.common.inputLabelTextStyle">
-                          The imported {{ (getDestinationField(expenseField.get('destination_field')?.value | snakeCaseToSpaceCase) | lowercase) }} 
+                          The imported {{ (getDestinationField(expenseField.get('destination_field')?.value | snakeCaseToSpaceCase) | lowercase) }}
                           <span> will be an available field when creating an expense.</span>
-                        </h5>        
+                        </h5>
                       </div>
                     </div>
                     <div class="configuration--input-toggle-section">
@@ -102,7 +102,7 @@
             </div>
             <div class="tw-pt-26-px" [ngClass]="brandingStyle.configuration.importFieldDependentField" *ngIf="brandingFeatureConfig.featureFlags.importSettings.dependentField && expenseField.get('source_field')?.value==='PROJECT' && expenseField.get('import_to_fyle')?.value && expenseField.get('destination_field')?.value === dependentDestinationValue" [formGroup]="form">
                 <div class="tw-flex" [ngClass]="brandingStyle.common.configurationBrandingClass">
-                    <label class="container tw-pl-24-px tw-text-14-px tw-text-form-label-text-color">{{helper.sentenseCaseConversion('Import Cost Code and Cost Type from ')}} {{uiExposedAppName}} as dependent fields.
+                    <label class="container tw-pl-24-px tw-text-14-px tw-text-form-label-text-color">{{helper.sentenseCaseConversion('Import Cost Code and' + (uiExposedAppName === AppName.INTACCT ? '/or' : '') + ' Cost Type from ')}} {{uiExposedAppName}} as dependent fields.
                         <a *ngIf="uiExposedAppName === AppName.SAGE300" class="tw-text-link-primary tw-w-fit tw-cursor-pointer tw-inline-flex tw-items-center"
                             (click)="windowService.openInNewTab(dependantFieldSupportArticleLink)">
                             Read More
@@ -141,7 +141,11 @@
                                 </p-dropdown>
                             </div>
                         </div>
-                        <p-inputSwitch class="input-toggle-section tw-pt-24-px" formControlName="dependentFieldImportToggle"></p-inputSwitch>
+                        @if (uiExposedAppName === AppName.INTACCT) {
+                            <p-inputSwitch class="input-toggle-section tw-pt-24-px" [formControlName]="dependentField.formController + 'ImportToggle'"></p-inputSwitch>
+                        } @else {
+                            <p-inputSwitch class="input-toggle-section tw-pt-24-px" formControlName="dependentFieldImportToggle"></p-inputSwitch>
+                        }
                     </div>
                     <div *ngIf="uiExposedAppName === AppName.SAGE300" class="tw-flex tw-mt-24-px" [ngClass]="brandingStyle.common.configurationBrandingClass">
                         <label class="container tw-pl-24-px tw-text-14-px tw-text-form-label-text-color">Auto-Export Commitment based on the Cost Code and Cost Category.
@@ -157,12 +161,12 @@
                         </label>
                     </div>
                 </div>
-            </div>                      
+            </div>
             <div class="tw-text-alert-toast tw-pt-4 tw-pl-1" *ngIf="form.get('expenseFields')?.hasError('duplicatefyleFieldOptions') || form.get('expenseFields')?.hasError('duplicateaccountingFieldOptions')">
                 *{{brandingConfig.brandName}} and {{uiExposedAppName}} Fields should be unique.
-            </div> 
-        </div>  
-    </div>               
+            </div>
+        </div>
+    </div>
     </div>
     <div *ngIf="showOrHideAddButton() && !isDestinationFixedImport" class="add-button-container">
         <app-svg-icon [svgSource]="'plus-square-medium'" [width]="'18px'" [height]="'18px'" [styleClasses]="'tw-cursor-pointer tw-text-mandatory-field-color'" (iconClick)="addExpenseField()"></app-svg-icon>


### PR DESCRIPTION
### Description
- Support cost code imports without importing cost types
- Sync the corresponding toggles with the field value
- Disable cost types when cost codes are not mapped
- Disable either field after a value is entered

<img width="866" alt="image" src="https://github.com/user-attachments/assets/768c3b04-700e-4298-8159-6b0f563299fe" />


## Clickup
https://app.clickup.com/t/86cybaenz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the reliability of cost type configurations by providing defined default values, preventing potential unexpected behavior.

- **New Features**
  - Added a new option to enable or disable cost type imports.
  - Updated the import settings interface with revised, more inclusive label text.
  - Introduced distinct toggles for importing cost codes and cost types, offering clearer and more granular user control.
  - Improved contextual accuracy in warning messages related to imported cost codes and types.
  - Enhanced dynamic behavior in the configuration import field based on application context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->