### PR TITLE
fix: users being redirected to qbd direct landing after onboarding

### DIFF
--- a/src/app/branding/fyle-branding-config.ts
+++ b/src/app/branding/fyle-branding-config.ts
@@ -141,7 +141,7 @@ export const fyleKbArticles: KbArticle[string] = {
             EXPORT_SETTING: `${brandingConfig.helpArticleDomain}/en/articles/10259583-quickbooks-desktop-integration-beta#h_1366df4107`,
             ADVANCED_SETTING: `${brandingConfig.helpArticleDomain}/en/articles/10259583-quickbooks-desktop-integration-beta#h_b3850646c0`,
             CONNECTOR: `${brandingConfig.helpArticleDomain}/en/articles/10259583-quickbooks-desktop-integration-beta#h_d3cc42849a`,
-            HELPER_ARTICLE: `${brandingConfig.helpArticleDomain}/en/articles/7882821-how-to-skip-exporting-specific-expenses-from-fyle-to-sage-intacct`
+            HELPER_ARTICLE: `${brandingConfig.helpArticleDomain}/en/articles/10259583-quickbooks-desktop-integration#h_d3cc42849a`
         }
     }
 };

--- a/src/app/integrations/qbd-direct/qbd-direct-onboarding/qbd-direct-onboarding-landing/qbd-direct-onboarding-landing.component.ts
+++ b/src/app/integrations/qbd-direct/qbd-direct-onboarding/qbd-direct-onboarding-landing/qbd-direct-onboarding-landing.component.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { brandingConfig, brandingContent, brandingDemoVideoLinks, brandingKbArticles } from 'src/app/branding/branding-config';
 import { AppName, QbdDirectOnboardingState } from 'src/app/core/models/enum/enum.model';
 import { QbdDirectWorkspace } from 'src/app/core/models/qbd-direct/db/qbd-direct-workspaces.model';
 import { WorkspaceService } from 'src/app/core/services/common/workspace.service';
+import { UserService } from 'src/app/core/services/misc/user.service';
 import { SharedModule } from 'src/app/shared/shared.module';
 
 @Component({
@@ -14,7 +15,7 @@ import { SharedModule } from 'src/app/shared/shared.module';
   templateUrl: './qbd-direct-onboarding-landing.component.html',
   styleUrl: './qbd-direct-onboarding-landing.component.scss'
 })
-export class QbdDirectOnboardingLandingComponent {
+export class QbdDirectOnboardingLandingComponent implements OnInit {
 
   appName: AppName = AppName.QBD_DIRECT;
 
@@ -30,7 +31,8 @@ export class QbdDirectOnboardingLandingComponent {
 
   constructor(
     private router: Router,
-    private workspaceService: WorkspaceService
+    private workspaceService: WorkspaceService,
+    private userService: UserService
   ) { }
 
   connectQbdDirect() {
@@ -39,6 +41,16 @@ export class QbdDirectOnboardingLandingComponent {
       this.workspaceService.setOnboardingState(workspaceResponse.onboarding_state);
       this.isQbdConnectionInProgress = false;
       this.router.navigate([`/integrations/qbd_direct/onboarding/pre_requisite/`]);
+    });
+  }
+
+  ngOnInit(): void {
+    const user = this.userService.getUserProfile();
+    this.workspaceService.getWorkspace(user.org_id).subscribe((workspaces: QbdDirectWorkspace[]) => {
+      workspaces = [];
+      if (workspaces.length && workspaces[0]?.onboarding_state !== QbdDirectOnboardingState.YET_TO_START) {
+        this.router.navigate([`/integrations/qbd_direct`]);
+      }
     });
   }
 

--- a/src/app/integrations/qbd-direct/qbd-direct-onboarding/qbd-direct-onboarding-landing/qbd-direct-onboarding-landing.component.ts
+++ b/src/app/integrations/qbd-direct/qbd-direct-onboarding/qbd-direct-onboarding-landing/qbd-direct-onboarding-landing.component.ts
@@ -47,7 +47,6 @@ export class QbdDirectOnboardingLandingComponent implements OnInit {
   ngOnInit(): void {
     const user = this.userService.getUserProfile();
     this.workspaceService.getWorkspace(user.org_id).subscribe((workspaces: QbdDirectWorkspace[]) => {
-      workspaces = [];
       if (workspaces.length && workspaces[0]?.onboarding_state !== QbdDirectOnboardingState.YET_TO_START) {
         this.router.navigate([`/integrations/qbd_direct`]);
       }

--- a/src/app/integrations/qbd-direct/qbd-direct-onboarding/qbd-direct-onboarding-pre-requisite/qbd-direct-onboarding-pre-requisite.component.ts
+++ b/src/app/integrations/qbd-direct/qbd-direct-onboarding/qbd-direct-onboarding-pre-requisite/qbd-direct-onboarding-pre-requisite.component.ts
@@ -29,7 +29,7 @@ export class QbdDirectOnboardingPreRequisiteComponent {
 
   isLoading: boolean;
 
-  redirectLink: string = brandingKbArticles.onboardingArticles.QBO.CONNECTOR;
+  redirectLink: string = brandingKbArticles.onboardingArticles.QBD_DIRECT.CONNECTOR;
 
   brandingConfig: BrandingConfiguration = brandingConfig;
 


### PR DESCRIPTION
### Description
If the admin ends up on the onboarding landing page, redirect them based on the onboarding state

## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the onboarding landing experience to check your profile and workspace progress when you arrive. Based on your current onboarding status, you are automatically directed to the main integration screen, streamlining your workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->