### PR TITLE
fix: bank account field not showing for checks and JEs

### DIFF
--- a/src/app/core/models/qbo/qbo-configuration/qbo-export-setting.model.ts
+++ b/src/app/core/models/qbo/qbo-configuration/qbo-export-setting.model.ts
@@ -190,10 +190,10 @@ export class QBOExportSettingModel extends ExportSettingModel {
     ];
   }
 
-  static getMandatoryField(form: FormGroup, controllerName: string): boolean {
+  static getMandatoryField(form: FormGroup, employeeMappingValue: EmployeeFieldMapping, controllerName: string): boolean {
     switch (controllerName) {
       case 'bankAccount':
-        return form.controls.employeeMapping.value === EmployeeFieldMapping.EMPLOYEE && form.controls.reimbursableExportType.value && form.controls.reimbursableExportType.value !== QBOReimbursableExpensesObject.EXPENSE;
+        return employeeMappingValue === EmployeeFieldMapping.EMPLOYEE && form.controls.reimbursableExportType.value && form.controls.reimbursableExportType.value !== QBOReimbursableExpensesObject.EXPENSE;
       case 'accountsPayable':
         return (form.controls.reimbursableExportType.value === QBOReimbursableExpensesObject.BILL || (form.controls.reimbursableExportType.value === QBOReimbursableExpensesObject.JOURNAL_ENTRY && form.controls.employeeMapping.value === EmployeeFieldMapping.VENDOR)) || (form.controls.creditCardExportType.value === QBOCorporateCreditCardExpensesObject.BILL);
       case 'defaultCCCAccount':

--- a/src/app/core/services/qbo/qbo-configuration/qbo-export-settings.service.ts
+++ b/src/app/core/services/qbo/qbo-configuration/qbo-export-settings.service.ts
@@ -4,7 +4,7 @@ import { WorkspaceService } from '../../common/workspace.service';
 import { ApiService } from '../../common/api.service';
 import { QBOExportSettingGet, QBOExportSettingModel, QBOExportSettingPost } from 'src/app/core/models/qbo/qbo-configuration/qbo-export-setting.model';
 import { ExportModuleRule } from 'src/app/core/models/common/export-settings.model';
-import { FormGroup } from '@angular/forms';
+import { AbstractControl, FormGroup } from '@angular/forms';
 import { HelperUtility } from 'src/app/core/models/common/helper.model';
 
 @Injectable({
@@ -29,7 +29,7 @@ export class QboExportSettingsService {
     return this.apiService.put(`/v2/workspaces/${this.workspaceService.getWorkspaceId()}/export_settings/`, exportSettingsPayload);
   }
 
-  setupDynamicValidators(form: FormGroup, values: ExportModuleRule, selectedValue: string): void {
+  setupDynamicValidators(form: FormGroup, employeeMappingControl: AbstractControl | null, values: ExportModuleRule, selectedValue: string): void {
     Object.entries(values.requiredValue).forEach(([key, value]) => {
       if (key === selectedValue) {
         value.forEach((formController: string) => {
@@ -37,7 +37,7 @@ export class QboExportSettingsService {
             this.creditCardExportTypeChange.emit(selectedValue);
           }
 
-          const isFieldMandatory = QBOExportSettingModel.getMandatoryField(form, formController);
+          const isFieldMandatory = QBOExportSettingModel.getMandatoryField(form, employeeMappingControl?.value, formController);
           if (isFieldMandatory) {
             this.mandatoryFormController.push(formController);
             HelperUtility.markControllerAsRequired(form, formController);
@@ -55,11 +55,11 @@ export class QboExportSettingsService {
     });
   }
 
-  setExportTypeValidatorsAndWatchers(exportTypeValidatorRule: ExportModuleRule[], form: FormGroup): void {
+  setExportTypeValidatorsAndWatchers(exportTypeValidatorRule: ExportModuleRule[], form: FormGroup, employeeMappingControl: AbstractControl | null): void {
     Object.values(exportTypeValidatorRule).forEach((values) => {
       form.controls[values.formController].valueChanges.subscribe((selectedValue) => {
         this.mandatoryFormController = [];
-        this.setupDynamicValidators(form, values, selectedValue);
+        this.setupDynamicValidators(form, employeeMappingControl, values, selectedValue);
       });
     });
   }

--- a/src/app/integrations/qbo/qbo-onboarding/qbo-clone-settings/qbo-clone-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-onboarding/qbo-clone-settings/qbo-clone-settings.component.ts
@@ -483,15 +483,18 @@ export class QboCloneSettingsComponent implements OnInit {
 
         this.helperService.setConfigurationSettingValidatorsAndWatchers(exportSettingValidatorRule, this.exportSettingForm);
 
+        const employeeMappingControl = this.employeeSettingForm.get('employeeMapping');
+
         if (cloneSetting.export_settings.workspace_general_settings.reimbursable_expenses_object) {
-          this.exportSettingService.setupDynamicValidators(this.exportSettingForm, exportModuleRule[0], cloneSetting.export_settings.workspace_general_settings.reimbursable_expenses_object);
+          this.exportSettingService.setupDynamicValidators(this.exportSettingForm, employeeMappingControl, exportModuleRule[0], cloneSetting.export_settings.workspace_general_settings.reimbursable_expenses_object);
         }
 
         if (cloneSetting.export_settings.workspace_general_settings.corporate_credit_card_expenses_object) {
-          this.exportSettingService.setupDynamicValidators(this.exportSettingForm, exportModuleRule[1], cloneSetting.export_settings.workspace_general_settings.corporate_credit_card_expenses_object);
+          this.exportSettingService.setupDynamicValidators(this.exportSettingForm, employeeMappingControl, exportModuleRule[1], cloneSetting.export_settings.workspace_general_settings.corporate_credit_card_expenses_object);
         }
 
-        this.exportSettingService.setExportTypeValidatorsAndWatchers(exportModuleRule, this.exportSettingForm);
+
+        this.exportSettingService.setExportTypeValidatorsAndWatchers(exportModuleRule, this.exportSettingForm, this.employeeSettingForm.get('employeeMapping'));
 
         this.setupCustomWatchers();
 

--- a/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.html
+++ b/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.html
@@ -47,7 +47,7 @@
                                     [isFieldMandatory]="true"
                                     [mandatoryErrorListName]="'bank account'"
                                     [label]="'To which bank account should the ' + (exportSettingForm.get('reimbursableExportType')?.value | snakeCaseToSpaceCase | lowercase) + ' be posted to?'"
-                                    [subLabel]="'All the offset entry in the journal will be posted to the selected bank account.'"
+                                    [subLabel]="'The expenses exported will be posted to the selected bank account.'"
                                     [destinationAttributes]="bankAccounts"
                                     [destinationOptionKey]="QboExportSettingDestinationOptionKey.BANK_ACCOUNT"
                                     [isOptionSearchInProgress]="isOptionSearchInProgress"
@@ -340,7 +340,7 @@
                             [formControllerName]="'creditCardExportDate'">
                         </app-configuration-select-field>
 
-                        <app-configuration-select-field *ngIf="brandingFeatureConfig.featureFlags.exportSettings.splitExpenseGrouping && 
+                        <app-configuration-select-field *ngIf="brandingFeatureConfig.featureFlags.exportSettings.splitExpenseGrouping &&
                         exportSettingForm.get('creditCardExportType')?.value === QBOCorporateCreditCardExpensesObject.CREDIT_CARD_PURCHASE"
                         [form]="exportSettingForm"
                         [isFieldMandatory]="true"

--- a/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
@@ -529,13 +529,14 @@ return of(null);
 
       this.helperService.setConfigurationSettingValidatorsAndWatchers(exportSettingValidatorRule, this.exportSettingForm);
 
+      const employeeMappingControl = this.employeeSettingForm.get('employeeMapping');
       if (this.exportSettings.workspace_general_settings?.reimbursable_expenses_object) {
-        this.exportSettingService.setupDynamicValidators(this.exportSettingForm, exportModuleRule[0], this.exportSettings.workspace_general_settings?.reimbursable_expenses_object);
+        this.exportSettingService.setupDynamicValidators(this.exportSettingForm, employeeMappingControl, exportModuleRule[0], this.exportSettings.workspace_general_settings?.reimbursable_expenses_object);
         this.helperService.setOrClearValidators(this.exportSettings.workspace_general_settings?.reimbursable_expenses_object, exportSettingValidatorRule.reimbursableExpense, this.exportSettingForm);
       }
 
       if (this.exportSettings.workspace_general_settings?.corporate_credit_card_expenses_object) {
-        this.exportSettingService.setupDynamicValidators(this.exportSettingForm, exportModuleRule[1], this.exportSettings.workspace_general_settings?.corporate_credit_card_expenses_object);
+        this.exportSettingService.setupDynamicValidators(this.exportSettingForm, employeeMappingControl, exportModuleRule[1], this.exportSettings.workspace_general_settings?.corporate_credit_card_expenses_object);
         this.helperService.setOrClearValidators(this.exportSettings.workspace_general_settings?.corporate_credit_card_expenses_object, exportSettingValidatorRule.creditCardExpense, this.exportSettingForm);
       }
 
@@ -546,7 +547,9 @@ return of(null);
       this.setupCustomDateOptionWatchers();
       this.optionSearchWatcher();
 
-      this.exportSettingService.setExportTypeValidatorsAndWatchers(exportModuleRule, this.exportSettingForm);
+      this.exportSettingService.setExportTypeValidatorsAndWatchers(
+        exportModuleRule, this.exportSettingForm, employeeMappingControl
+      );
 
       this.isLoading = false;
     });


### PR DESCRIPTION
### Description
Fixes the bug in QBO export settings, where we were reading the value for `employeeMapping` from the wrong form (`exportSettingForm` instead of `employeeSettingForm`).

## Clickup
https://app.clickup.com/t/86cyp2561


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved how mandatory field validation is determined in QuickBooks Online export settings by considering employee mapping selections.
  - Enhanced the setup of dynamic validators and watchers to incorporate employee mapping information, leading to more accurate form validation during onboarding and export settings configuration.
- **Bug Fixes**
  - Updated descriptive text for bank account selection to clarify expense posting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->