### PR TITLE
fix: revert standardization for Sage 300

### DIFF
--- a/src/app/core/models/common/export-settings.model.ts
+++ b/src/app/core/models/common/export-settings.model.ts
@@ -2,6 +2,7 @@ import { brandingContent } from "src/app/branding/branding-config";
 import { DefaultDestinationAttribute, DestinationAttribute } from "../db/destination-attribute.model";
 import { DestinationOptionKey, ExpenseGroupingFieldOption, ExportDateType, FundSource, IntacctCorporateCreditCardExpensesObject, IntacctExportSettingDestinationOptionKey, IntacctReimbursableExpensesObject, NetsuiteExportSettingDestinationOptionKey, QboExportSettingDestinationOptionKey, SplitExpenseGrouping } from "../enum/enum.model";
 import { SelectFormOption } from "./select-form-option.model";
+import { AbstractControl } from "@angular/forms";
 
 export type ExportSettingValidatorRule = {
     reimbursableExpense: string[];
@@ -21,140 +22,165 @@ export type ExportSettingOptionSearch = {
 };
 
 export class ExportSettingModel {
-    static getSplitExpenseGroupingOptions(): SelectFormOption[] {
-      return [
-        {
-          label: 'Single line item',
-          value: SplitExpenseGrouping.SINGLE_LINE_ITEM
-        },
-        {
-          label: 'Multiple line item',
-          value: SplitExpenseGrouping.MULTIPLE_LINE_ITEM
-        }
-      ];
-    }
-
-    static getExportGroup(exportGroups: string[] | null | undefined): string {
-        if (exportGroups) {
-            const exportGroup = exportGroups.find((exportGroup) => {
-                return exportGroup === ExpenseGroupingFieldOption.EXPENSE_ID || exportGroup === ExpenseGroupingFieldOption.REPORT_ID || exportGroup === ExpenseGroupingFieldOption.CLAIM_NUMBER || exportGroup === ExpenseGroupingFieldOption.SETTLEMENT_ID;
-            });
-            return exportGroup && exportGroup !== ExpenseGroupingFieldOption.REPORT_ID ? exportGroup : ExpenseGroupingFieldOption.CLAIM_NUMBER;
-        }
-        return '';
-    }
-
-    static formatGeneralMappingPayload(destinationAttribute: DestinationAttribute): DefaultDestinationAttribute {
-        return {
-            name: destinationAttribute.value,
-            id: destinationAttribute.destination_id
-        };
-    }
-
-    static constructCCCOptions(brandId: string) {
-        if (brandId === 'fyle') {
-            return [
-                {
-                  label: 'Bill',
-                  value: IntacctReimbursableExpensesObject.BILL
-                },
-                {
-                  label: 'Expense report',
-                  value: IntacctReimbursableExpensesObject.EXPENSE_REPORT
-                },
-                {
-                  label: 'Journal entry',
-                  value: IntacctCorporateCreditCardExpensesObject.JOURNAL_ENTRY
-                },
-                {
-                  label: 'Charge card transaction',
-                  value: IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION
-                }
-              ];
-        }
-            return [
-                {
-                  label: 'Charge card transaction',
-                  value: IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION
-                },
-                {
-                  label: 'Journal entry',
-                  value: IntacctCorporateCreditCardExpensesObject.JOURNAL_ENTRY
-                },
-                {
-                  label: 'Bill',
-                  value: IntacctReimbursableExpensesObject.BILL
-                }
-              ];
-
-    }
-
-    static getExpenseGroupingDateOptions(): SelectFormOption[] {
-      return [
-        {
-          label: 'Export date',
-          value: ExportDateType.CURRENT_DATE
-        },
-        {
-          label: 'Verification date',
-          value: ExportDateType.VERIFIED_AT
-        },
-        {
-          label: 'Spend date',
-          value: ExportDateType.SPENT_AT
-        },
-        {
-          label: 'Approval date',
-          value: ExportDateType.APPROVED_AT
-        },
-        {
-          label: 'Last spend date',
-          value: ExportDateType.LAST_SPENT_AT
-        },
-        {
-          label: 'Card transaction post date',
-          value: ExportDateType.POSTED_AT
-        }
-      ];
-    }
-
-    static constructExportDateOptions(isCoreCCCModule: boolean, expenseGrouping: ExpenseGroupingFieldOption, exportDateType: ExportDateType): SelectFormOption[] {
-
-      // Determine the excluded date based on expenseGrouping
-      const excludedSpendDateOption = [ExpenseGroupingFieldOption.EXPENSE_ID, ExpenseGroupingFieldOption.EXPENSE].includes(expenseGrouping)
-        ? ExportDateType.LAST_SPENT_AT
-        : ExportDateType.SPENT_AT;
-
-      // Deprecate APPROVED_AT and VERIFIED_AT - if the user has already selected one of them, show only that option
-      const excludedApprovedOrVerifiedOption = exportDateType === ExportDateType.APPROVED_AT ? [ExportDateType.VERIFIED_AT] : (exportDateType === ExportDateType.VERIFIED_AT ? [ExportDateType.APPROVED_AT] : [ExportDateType.APPROVED_AT, ExportDateType.VERIFIED_AT]);
-
-      // Determine the excluded date based on export Type
-      const excludedPostedAtOption = !isCoreCCCModule ? ExportDateType.POSTED_AT : null;
-
-      // Array of unwanted dates
-      const dateOptionsToBeExcluded = [excludedSpendDateOption, excludedPostedAtOption].concat(excludedApprovedOrVerifiedOption);
-
-      // Get base date options
-      const unfilteredDateOptions = this.getExpenseGroupingDateOptions();
-
-      // Filter out excluded and unwanted dates
-      return unfilteredDateOptions.filter(option =>
-        option.value !== null && !dateOptionsToBeExcluded.includes(option.value as ExportDateType)
-      );
-    }
-
-    static filterDateOptions(exportDateType: ExportDateType, dateOptions: SelectFormOption[]){
-      const dateOptionToRemove = exportDateType;
-      const filteredOptions = dateOptions.filter(option => option.value !== dateOptionToRemove);
-      return filteredOptions;
-    }
-
-    static constructGroupingDateOptions(exportGroupType: ExpenseGroupingFieldOption, dateOptions: SelectFormOption[]) {
-      if (exportGroupType === ExpenseGroupingFieldOption.EXPENSE_ID) {
-        return ExportSettingModel.filterDateOptions(ExportDateType.LAST_SPENT_AT, dateOptions);
-      } else if (exportGroupType===ExpenseGroupingFieldOption.CLAIM_NUMBER || exportGroupType===ExpenseGroupingFieldOption.REPORT_ID) {
-        return ExportSettingModel.filterDateOptions(ExportDateType.SPENT_AT, dateOptions);
+  static getSplitExpenseGroupingOptions(): SelectFormOption[] {
+    return [
+      {
+        label: 'Single line item',
+        value: SplitExpenseGrouping.SINGLE_LINE_ITEM
+      },
+      {
+        label: 'Multiple line item',
+        value: SplitExpenseGrouping.MULTIPLE_LINE_ITEM
       }
-      return dateOptions;
+    ];
+  }
+
+  static getExportGroup(exportGroups: string[] | null | undefined): string {
+      if (exportGroups) {
+          const exportGroup = exportGroups.find((exportGroup) => {
+              return exportGroup === ExpenseGroupingFieldOption.EXPENSE_ID || exportGroup === ExpenseGroupingFieldOption.REPORT_ID || exportGroup === ExpenseGroupingFieldOption.CLAIM_NUMBER || exportGroup === ExpenseGroupingFieldOption.SETTLEMENT_ID;
+          });
+          return exportGroup && exportGroup !== ExpenseGroupingFieldOption.REPORT_ID ? exportGroup : ExpenseGroupingFieldOption.CLAIM_NUMBER;
+      }
+      return '';
+  }
+
+  static formatGeneralMappingPayload(destinationAttribute: DestinationAttribute): DefaultDestinationAttribute {
+      return {
+          name: destinationAttribute.value,
+          id: destinationAttribute.destination_id
+      };
+  }
+
+  static constructCCCOptions(brandId: string) {
+      if (brandId === 'fyle') {
+          return [
+              {
+                label: 'Bill',
+                value: IntacctReimbursableExpensesObject.BILL
+              },
+              {
+                label: 'Expense report',
+                value: IntacctReimbursableExpensesObject.EXPENSE_REPORT
+              },
+              {
+                label: 'Journal entry',
+                value: IntacctCorporateCreditCardExpensesObject.JOURNAL_ENTRY
+              },
+              {
+                label: 'Charge card transaction',
+                value: IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION
+              }
+            ];
+      }
+          return [
+              {
+                label: 'Charge card transaction',
+                value: IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION
+              },
+              {
+                label: 'Journal entry',
+                value: IntacctCorporateCreditCardExpensesObject.JOURNAL_ENTRY
+              },
+              {
+                label: 'Bill',
+                value: IntacctReimbursableExpensesObject.BILL
+              }
+            ];
+
+  }
+
+  static getExpenseGroupingDateOptions(): SelectFormOption[] {
+    return [
+      {
+        label: 'Export date',
+        value: ExportDateType.CURRENT_DATE
+      },
+      {
+        label: 'Verification date',
+        value: ExportDateType.VERIFIED_AT
+      },
+      {
+        label: 'Spend date',
+        value: ExportDateType.SPENT_AT
+      },
+      {
+        label: 'Approval date',
+        value: ExportDateType.APPROVED_AT
+      },
+      {
+        label: 'Last spend date',
+        value: ExportDateType.LAST_SPENT_AT
+      },
+      {
+        label: 'Card transaction post date',
+        value: ExportDateType.POSTED_AT
+      }
+    ];
+  }
+
+  static constructExportDateOptions(
+    isCoreCCCModule: boolean,
+    expenseGrouping: ExpenseGroupingFieldOption,
+    exportDateType: ExportDateType,
+    { allowPostedAt }: {allowPostedAt?: boolean} = {}
+  ): SelectFormOption[] {
+
+    // Determine the excluded date based on expenseGrouping
+    const excludedSpendDateOption = [ExpenseGroupingFieldOption.EXPENSE_ID, ExpenseGroupingFieldOption.EXPENSE].includes(expenseGrouping)
+      ? ExportDateType.LAST_SPENT_AT
+      : ExportDateType.SPENT_AT;
+
+    // Deprecate APPROVED_AT and VERIFIED_AT - if the user has already selected one of them, show only that option
+    const excludedApprovedOrVerifiedOption = exportDateType === ExportDateType.APPROVED_AT ? [ExportDateType.VERIFIED_AT] : (exportDateType === ExportDateType.VERIFIED_AT ? [ExportDateType.APPROVED_AT] : [ExportDateType.APPROVED_AT, ExportDateType.VERIFIED_AT]);
+
+    // Determine the excluded date based on export Type
+    let excludedPostedAtOption = !isCoreCCCModule ? ExportDateType.POSTED_AT : null;
+
+    // Exceptions for users who have already selected posted_at
+    if (allowPostedAt) {
+      excludedPostedAtOption = null;
     }
+
+    // Array of unwanted dates
+    const dateOptionsToBeExcluded = [excludedSpendDateOption, excludedPostedAtOption].concat(excludedApprovedOrVerifiedOption);
+
+    // Get base date options
+    const unfilteredDateOptions = this.getExpenseGroupingDateOptions();
+
+    // Filter out excluded and unwanted dates
+    return unfilteredDateOptions.filter(option =>
+      option.value !== null && !dateOptionsToBeExcluded.includes(option.value as ExportDateType)
+    );
+  }
+
+  static filterDateOptions(exportDateType: ExportDateType, dateOptions: SelectFormOption[]){
+    const dateOptionToRemove = exportDateType;
+    const filteredOptions = dateOptions.filter(option => option.value !== dateOptionToRemove);
+    return filteredOptions;
+  }
+
+  static constructGroupingDateOptions(exportGroupType: ExpenseGroupingFieldOption, dateOptions: SelectFormOption[]) {
+    if (exportGroupType === ExpenseGroupingFieldOption.EXPENSE_ID) {
+      return ExportSettingModel.filterDateOptions(ExportDateType.LAST_SPENT_AT, dateOptions);
+    } else if (exportGroupType===ExpenseGroupingFieldOption.CLAIM_NUMBER || exportGroupType===ExpenseGroupingFieldOption.REPORT_ID) {
+      return ExportSettingModel.filterDateOptions(ExportDateType.SPENT_AT, dateOptions);
+    }
+    return dateOptions;
+  }
+
+  static clearInvalidSelectedOption<T>(control: AbstractControl<T | null> | null, validOptions: T[]) {
+    const selectedOption = control?.value;
+    if (selectedOption && !validOptions.includes(selectedOption)) {
+      control?.setValue(null);
+    }
+  }
+
+  /**
+   * If the current selected option is not in the valid options, clear the field
+   */
+  static clearInvalidDateOption(control: AbstractControl | null, validDateOptions: SelectFormOption[]) {
+    const validOptions = validDateOptions.map((option) => option.value);
+    return ExportSettingModel.clearInvalidSelectedOption(control, validOptions);
+  }
 }

--- a/src/app/integrations/business-central/business-central-shared/business-central-export-settings/business-central-export-settings.component.ts
+++ b/src/app/integrations/business-central/business-central-shared/business-central-export-settings/business-central-export-settings.component.ts
@@ -160,21 +160,19 @@ export class BusinessCentralExportSettingsComponent implements OnInit {
         this.exportSettingForm.controls.reimbursableExportDate.value
       );
 
-      // If the current selected date option is not in the new options, clear the field
-      const newValues = this.reimbursableExpenseGroupingDateOptions.map((option) => option.value);
-      if (!newValues.includes(this.exportSettingForm.controls.reimbursableExportDate.value)) {
-        this.exportSettingForm.controls.reimbursableExportDate.setValue(null);
-      }
+      ExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('reimbursableExportDate'),
+        this.reimbursableExpenseGroupingDateOptions
+      );
     });
 
     this.exportSettingForm.controls.cccExportGroup.valueChanges.subscribe((cccExportGroup) => {
       this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(true, cccExportGroup, this.exportSettingForm.controls.cccExportDate.value);
 
-      // If the current selected date option is not in the new options, clear the field
-      const newValues = this.cccExpenseGroupingDateOptions.map((option) => option.value);
-      if (!newValues.includes(this.exportSettingForm.controls.cccExportDate.value)) {
-        this.exportSettingForm.controls.cccExportDate.setValue(null);
-      }
+      ExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('cccExportDate'),
+        this.cccExpenseGroupingDateOptions
+      );
     });
 
     this.exportSettingForm.get('reimbursableExportType')?.valueChanges.subscribe(() => this.updateExpenseGroupingValues());

--- a/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.spec.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.spec.ts
@@ -427,25 +427,6 @@ describe('IntacctExportSettingsComponent', () => {
   });
 
   describe('Edge Cases', () => {
-    it('should set the correct CCC expense grouping date options when CCC expense object is unset', () => {
-      component.exportSettings = {
-        configurations: {
-          corporate_credit_card_expenses_object: null
-        }
-      } as ExportSettingGet;
-      spyOn<any>(component, 'setCCExpenseDateOptions');
-
-      component['setupCCCExpenseGroupingDateOptions']();
-      expect(component['setCCExpenseDateOptions']).toHaveBeenCalledOnceWith(IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION);
-    });
-
-    it('should default CCC expense grouping date options to reimbursable grouping date options for non-charge card transactions', () => {
-      fixture.detectChanges();
-
-      component['setCCExpenseDateOptions'](IntacctCorporateCreditCardExpensesObject.BILL);
-      expect(component.cccExpenseGroupingDateOptions).toEqual(component.reimbursableExpenseGroupingDateOptions);
-    });
-
     it('should set the correct CCC expense grouping date options when grouping by report', () => {
       fixture.detectChanges();
 

--- a/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
@@ -339,14 +339,30 @@ export class QboExportSettingsComponent implements OnInit {
 
     this.exportSettingForm.controls.reimbursableExportGroup?.valueChanges.subscribe((reimbursableExportGroup) => {
       this.reimbursableExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(false, reimbursableExportGroup, this.exportSettingForm.controls.reimbursableExportDate.value);
+
+      ExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('reimbursableExportDate'),
+        this.reimbursableExpenseGroupingDateOptions
+      );
     });
 
     this.exportSettingForm.controls.creditCardExportGroup?.valueChanges.subscribe((creditCardExportGroup) => {
-      if (this.exportSettingForm.get('creditCardExportType')?.value && this.exportSettingForm.get('creditCardExportType')?.value !== QBOCorporateCreditCardExpensesObject.CREDIT_CARD_PURCHASE && this.exportSettingForm.get('creditCardExportType')?.value !== QBOCorporateCreditCardExpensesObject.DEBIT_CARD_EXPENSE) {
-        this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(false, creditCardExportGroup, this.exportSettingForm.controls.creditCardExportDate.value);
-      } else {
-        this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(true, creditCardExportGroup, this.exportSettingForm.controls.creditCardExportDate.value);
-      }
+
+      // In QBO, credit card purchase and 'debit & credit card expense' are core modules
+      // (Card transaction post date is available for these modules)
+      const isCoreCCCModule = [
+        QBOCorporateCreditCardExpensesObject.CREDIT_CARD_PURCHASE,
+        QBOCorporateCreditCardExpensesObject.DEBIT_CARD_EXPENSE
+      ].includes(this.exportSettingForm.get('creditCardExportType')?.value);
+
+      this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(
+        isCoreCCCModule, creditCardExportGroup, this.exportSettingForm.controls.creditCardExportDate.value
+      );
+
+      ExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('creditCardExportDate'),
+        this.cccExpenseGroupingDateOptions
+      );
     });
   }
 

--- a/src/app/integrations/sage300/sage300-shared/sage300-export-settings/sage300-export-settings.component.ts
+++ b/src/app/integrations/sage300/sage300-shared/sage300-export-settings/sage300-export-settings.component.ts
@@ -121,11 +121,13 @@ export class Sage300ExportSettingsComponent implements OnInit {
 
   private setupCustomWatchers(): void {
     this.exportSettingForm.controls.reimbursableExportGroup?.valueChanges.subscribe((reimbursableExportGroup) => {
-      this.reimbursableExpenseGroupingDateOptions = CommonExportSettingModel.constructExportDateOptions(false, reimbursableExportGroup, this.exportSettingForm.controls.reimbursableExportDate.value);
+      this.reimbursableExpenseGroupingDateOptions = this.exportSettingService.getReimbursableExpenseGroupingDateOptions();
+      this.reimbursableExpenseGroupingDateOptions = CommonExportSettingModel.constructGroupingDateOptions(reimbursableExportGroup, this.reimbursableExpenseGroupingDateOptions);
     });
 
     this.exportSettingForm.controls.cccExportGroup?.valueChanges.subscribe((cccExportGroup) => {
-      this.cccExpenseGroupingDateOptions = CommonExportSettingModel.constructExportDateOptions(true, cccExportGroup, this.exportSettingForm.controls.cccExportDate.value);
+      this.cccExpenseGroupingDateOptions = this.exportSettingService.getCCCExpenseGroupingDateOptions();
+      this.cccExpenseGroupingDateOptions = CommonExportSettingModel.constructGroupingDateOptions(cccExportGroup, this.cccExpenseGroupingDateOptions);
     });
   }
 

--- a/src/app/integrations/sage300/sage300-shared/sage300-export-settings/sage300-export-settings.component.ts
+++ b/src/app/integrations/sage300/sage300-shared/sage300-export-settings/sage300-export-settings.component.ts
@@ -123,11 +123,23 @@ export class Sage300ExportSettingsComponent implements OnInit {
     this.exportSettingForm.controls.reimbursableExportGroup?.valueChanges.subscribe((reimbursableExportGroup) => {
       this.reimbursableExpenseGroupingDateOptions = this.exportSettingService.getReimbursableExpenseGroupingDateOptions();
       this.reimbursableExpenseGroupingDateOptions = CommonExportSettingModel.constructGroupingDateOptions(reimbursableExportGroup, this.reimbursableExpenseGroupingDateOptions);
+
+      const validOptions = this.getExportDate(this.reimbursableExpenseGroupingDateOptions, 'reimbursableExportGroup');
+      CommonExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('reimbursableExportDate'),
+        validOptions
+      );
     });
 
     this.exportSettingForm.controls.cccExportGroup?.valueChanges.subscribe((cccExportGroup) => {
       this.cccExpenseGroupingDateOptions = this.exportSettingService.getCCCExpenseGroupingDateOptions();
       this.cccExpenseGroupingDateOptions = CommonExportSettingModel.constructGroupingDateOptions(cccExportGroup, this.cccExpenseGroupingDateOptions);
+
+      const validOptions = this.getExportDate(this.cccExpenseGroupingDateOptions, 'cccExportGroup');
+      CommonExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('cccExportDate'),
+        validOptions
+      );
     });
   }
 


### PR DESCRIPTION
### Description
Keep the old behaviour for Sage 300 since we dont support `spent_at` and `current_date`

## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**  
  - Improved logic for updating and validating grouping date options when export group selections change, ensuring invalid date options are cleared and only valid choices are shown.  
  - Enhanced handling of special cases allowing the "posted_at" date option in specific credit card export scenarios.  
  - Consolidated and refactored date option validation across multiple export settings for consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->