### PR TITLE
fix: clear invalid date values across all apps

### DIFF
--- a/src/app/core/models/common/export-settings.model.ts
+++ b/src/app/core/models/common/export-settings.model.ts
@@ -2,6 +2,7 @@ import { brandingContent } from "src/app/branding/branding-config";
 import { DefaultDestinationAttribute, DestinationAttribute } from "../db/destination-attribute.model";
 import { DestinationOptionKey, ExpenseGroupingFieldOption, ExportDateType, FundSource, IntacctCorporateCreditCardExpensesObject, IntacctExportSettingDestinationOptionKey, IntacctReimbursableExpensesObject, NetsuiteExportSettingDestinationOptionKey, QboExportSettingDestinationOptionKey, SplitExpenseGrouping } from "../enum/enum.model";
 import { SelectFormOption } from "./select-form-option.model";
+import { AbstractControl } from "@angular/forms";
 
 export type ExportSettingValidatorRule = {
     reimbursableExpense: string[];
@@ -21,140 +22,155 @@ export type ExportSettingOptionSearch = {
 };
 
 export class ExportSettingModel {
-    static getSplitExpenseGroupingOptions(): SelectFormOption[] {
-      return [
-        {
-          label: 'Single line item',
-          value: SplitExpenseGrouping.SINGLE_LINE_ITEM
-        },
-        {
-          label: 'Multiple line item',
-          value: SplitExpenseGrouping.MULTIPLE_LINE_ITEM
-        }
-      ];
-    }
-
-    static getExportGroup(exportGroups: string[] | null | undefined): string {
-        if (exportGroups) {
-            const exportGroup = exportGroups.find((exportGroup) => {
-                return exportGroup === ExpenseGroupingFieldOption.EXPENSE_ID || exportGroup === ExpenseGroupingFieldOption.REPORT_ID || exportGroup === ExpenseGroupingFieldOption.CLAIM_NUMBER || exportGroup === ExpenseGroupingFieldOption.SETTLEMENT_ID;
-            });
-            return exportGroup && exportGroup !== ExpenseGroupingFieldOption.REPORT_ID ? exportGroup : ExpenseGroupingFieldOption.CLAIM_NUMBER;
-        }
-        return '';
-    }
-
-    static formatGeneralMappingPayload(destinationAttribute: DestinationAttribute): DefaultDestinationAttribute {
-        return {
-            name: destinationAttribute.value,
-            id: destinationAttribute.destination_id
-        };
-    }
-
-    static constructCCCOptions(brandId: string) {
-        if (brandId === 'fyle') {
-            return [
-                {
-                  label: 'Bill',
-                  value: IntacctReimbursableExpensesObject.BILL
-                },
-                {
-                  label: 'Expense report',
-                  value: IntacctReimbursableExpensesObject.EXPENSE_REPORT
-                },
-                {
-                  label: 'Journal entry',
-                  value: IntacctCorporateCreditCardExpensesObject.JOURNAL_ENTRY
-                },
-                {
-                  label: 'Charge card transaction',
-                  value: IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION
-                }
-              ];
-        }
-            return [
-                {
-                  label: 'Charge card transaction',
-                  value: IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION
-                },
-                {
-                  label: 'Journal entry',
-                  value: IntacctCorporateCreditCardExpensesObject.JOURNAL_ENTRY
-                },
-                {
-                  label: 'Bill',
-                  value: IntacctReimbursableExpensesObject.BILL
-                }
-              ];
-
-    }
-
-    static getExpenseGroupingDateOptions(): SelectFormOption[] {
-      return [
-        {
-          label: 'Export date',
-          value: ExportDateType.CURRENT_DATE
-        },
-        {
-          label: 'Verification date',
-          value: ExportDateType.VERIFIED_AT
-        },
-        {
-          label: 'Spend date',
-          value: ExportDateType.SPENT_AT
-        },
-        {
-          label: 'Approval date',
-          value: ExportDateType.APPROVED_AT
-        },
-        {
-          label: 'Last spend date',
-          value: ExportDateType.LAST_SPENT_AT
-        },
-        {
-          label: 'Card transaction post date',
-          value: ExportDateType.POSTED_AT
-        }
-      ];
-    }
-
-    static constructExportDateOptions(isCoreCCCModule: boolean, expenseGrouping: ExpenseGroupingFieldOption, exportDateType: ExportDateType): SelectFormOption[] {
-
-      // Determine the excluded date based on expenseGrouping
-      const excludedSpendDateOption = [ExpenseGroupingFieldOption.EXPENSE_ID, ExpenseGroupingFieldOption.EXPENSE].includes(expenseGrouping)
-        ? ExportDateType.LAST_SPENT_AT
-        : ExportDateType.SPENT_AT;
-
-      // Deprecate APPROVED_AT and VERIFIED_AT - if the user has already selected one of them, show only that option
-      const excludedApprovedOrVerifiedOption = exportDateType === ExportDateType.APPROVED_AT ? [ExportDateType.VERIFIED_AT] : (exportDateType === ExportDateType.VERIFIED_AT ? [ExportDateType.APPROVED_AT] : [ExportDateType.APPROVED_AT, ExportDateType.VERIFIED_AT]);
-
-      // Determine the excluded date based on export Type
-      const excludedPostedAtOption = !isCoreCCCModule ? ExportDateType.POSTED_AT : null;
-
-      // Array of unwanted dates
-      const dateOptionsToBeExcluded = [excludedSpendDateOption, excludedPostedAtOption].concat(excludedApprovedOrVerifiedOption);
-
-      // Get base date options
-      const unfilteredDateOptions = this.getExpenseGroupingDateOptions();
-
-      // Filter out excluded and unwanted dates
-      return unfilteredDateOptions.filter(option =>
-        option.value !== null && !dateOptionsToBeExcluded.includes(option.value as ExportDateType)
-      );
-    }
-
-    static filterDateOptions(exportDateType: ExportDateType, dateOptions: SelectFormOption[]){
-      const dateOptionToRemove = exportDateType;
-      const filteredOptions = dateOptions.filter(option => option.value !== dateOptionToRemove);
-      return filteredOptions;
-    }
-
-    static constructGroupingDateOptions(exportGroupType: ExpenseGroupingFieldOption, dateOptions: SelectFormOption[]) {
-      if (exportGroupType === ExpenseGroupingFieldOption.EXPENSE_ID) {
-        return ExportSettingModel.filterDateOptions(ExportDateType.LAST_SPENT_AT, dateOptions);
-      } else if (exportGroupType===ExpenseGroupingFieldOption.CLAIM_NUMBER || exportGroupType===ExpenseGroupingFieldOption.REPORT_ID) {
-        return ExportSettingModel.filterDateOptions(ExportDateType.SPENT_AT, dateOptions);
+  static getSplitExpenseGroupingOptions(): SelectFormOption[] {
+    return [
+      {
+        label: 'Single line item',
+        value: SplitExpenseGrouping.SINGLE_LINE_ITEM
+      },
+      {
+        label: 'Multiple line item',
+        value: SplitExpenseGrouping.MULTIPLE_LINE_ITEM
       }
-      return dateOptions;
+    ];
+  }
+
+  static getExportGroup(exportGroups: string[] | null | undefined): string {
+      if (exportGroups) {
+          const exportGroup = exportGroups.find((exportGroup) => {
+              return exportGroup === ExpenseGroupingFieldOption.EXPENSE_ID || exportGroup === ExpenseGroupingFieldOption.REPORT_ID || exportGroup === ExpenseGroupingFieldOption.CLAIM_NUMBER || exportGroup === ExpenseGroupingFieldOption.SETTLEMENT_ID;
+          });
+          return exportGroup && exportGroup !== ExpenseGroupingFieldOption.REPORT_ID ? exportGroup : ExpenseGroupingFieldOption.CLAIM_NUMBER;
+      }
+      return '';
+  }
+
+  static formatGeneralMappingPayload(destinationAttribute: DestinationAttribute): DefaultDestinationAttribute {
+      return {
+          name: destinationAttribute.value,
+          id: destinationAttribute.destination_id
+      };
+  }
+
+  static constructCCCOptions(brandId: string) {
+      if (brandId === 'fyle') {
+          return [
+              {
+                label: 'Bill',
+                value: IntacctReimbursableExpensesObject.BILL
+              },
+              {
+                label: 'Expense report',
+                value: IntacctReimbursableExpensesObject.EXPENSE_REPORT
+              },
+              {
+                label: 'Journal entry',
+                value: IntacctCorporateCreditCardExpensesObject.JOURNAL_ENTRY
+              },
+              {
+                label: 'Charge card transaction',
+                value: IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION
+              }
+            ];
+      }
+          return [
+              {
+                label: 'Charge card transaction',
+                value: IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION
+              },
+              {
+                label: 'Journal entry',
+                value: IntacctCorporateCreditCardExpensesObject.JOURNAL_ENTRY
+              },
+              {
+                label: 'Bill',
+                value: IntacctReimbursableExpensesObject.BILL
+              }
+            ];
+
+  }
+
+  static getExpenseGroupingDateOptions(): SelectFormOption[] {
+    return [
+      {
+        label: 'Export date',
+        value: ExportDateType.CURRENT_DATE
+      },
+      {
+        label: 'Verification date',
+        value: ExportDateType.VERIFIED_AT
+      },
+      {
+        label: 'Spend date',
+        value: ExportDateType.SPENT_AT
+      },
+      {
+        label: 'Approval date',
+        value: ExportDateType.APPROVED_AT
+      },
+      {
+        label: 'Last spend date',
+        value: ExportDateType.LAST_SPENT_AT
+      },
+      {
+        label: 'Card transaction post date',
+        value: ExportDateType.POSTED_AT
+      }
+    ];
+  }
+
+  static constructExportDateOptions(isCoreCCCModule: boolean, expenseGrouping: ExpenseGroupingFieldOption, exportDateType: ExportDateType): SelectFormOption[] {
+
+    // Determine the excluded date based on expenseGrouping
+    const excludedSpendDateOption = [ExpenseGroupingFieldOption.EXPENSE_ID, ExpenseGroupingFieldOption.EXPENSE].includes(expenseGrouping)
+      ? ExportDateType.LAST_SPENT_AT
+      : ExportDateType.SPENT_AT;
+
+    // Deprecate APPROVED_AT and VERIFIED_AT - if the user has already selected one of them, show only that option
+    const excludedApprovedOrVerifiedOption = exportDateType === ExportDateType.APPROVED_AT ? [ExportDateType.VERIFIED_AT] : (exportDateType === ExportDateType.VERIFIED_AT ? [ExportDateType.APPROVED_AT] : [ExportDateType.APPROVED_AT, ExportDateType.VERIFIED_AT]);
+
+    // Determine the excluded date based on export Type
+    const excludedPostedAtOption = !isCoreCCCModule ? ExportDateType.POSTED_AT : null;
+
+    // Array of unwanted dates
+    const dateOptionsToBeExcluded = [excludedSpendDateOption, excludedPostedAtOption].concat(excludedApprovedOrVerifiedOption);
+
+    // Get base date options
+    const unfilteredDateOptions = this.getExpenseGroupingDateOptions();
+
+    // Filter out excluded and unwanted dates
+    return unfilteredDateOptions.filter(option =>
+      option.value !== null && !dateOptionsToBeExcluded.includes(option.value as ExportDateType)
+    );
+  }
+
+  static filterDateOptions(exportDateType: ExportDateType, dateOptions: SelectFormOption[]){
+    const dateOptionToRemove = exportDateType;
+    const filteredOptions = dateOptions.filter(option => option.value !== dateOptionToRemove);
+    return filteredOptions;
+  }
+
+  static constructGroupingDateOptions(exportGroupType: ExpenseGroupingFieldOption, dateOptions: SelectFormOption[]) {
+    if (exportGroupType === ExpenseGroupingFieldOption.EXPENSE_ID) {
+      return ExportSettingModel.filterDateOptions(ExportDateType.LAST_SPENT_AT, dateOptions);
+    } else if (exportGroupType===ExpenseGroupingFieldOption.CLAIM_NUMBER || exportGroupType===ExpenseGroupingFieldOption.REPORT_ID) {
+      return ExportSettingModel.filterDateOptions(ExportDateType.SPENT_AT, dateOptions);
     }
+    return dateOptions;
+  }
+
+  static clearInvalidSelectedOption<T>(control: AbstractControl<T | null> | null, validOptions: T[]) {
+    const selectedOption = control?.value;
+    if (selectedOption && !validOptions.includes(selectedOption)) {
+      control?.setValue(null);
+    }
+  }
+
+  /**
+   * If the current selected option is not in the valid options, clear the field
+   */
+  static clearInvalidDateOption(control: AbstractControl | null, validDateOptions: SelectFormOption[]) {
+    const validOptions = validDateOptions.map((option) => option.value);
+    return ExportSettingModel.clearInvalidSelectedOption(control, validOptions);
+  }
 }

--- a/src/app/core/models/common/export-settings.model.ts
+++ b/src/app/core/models/common/export-settings.model.ts
@@ -119,7 +119,12 @@ export class ExportSettingModel {
     ];
   }
 
-  static constructExportDateOptions(isCoreCCCModule: boolean, expenseGrouping: ExpenseGroupingFieldOption, exportDateType: ExportDateType): SelectFormOption[] {
+  static constructExportDateOptions(
+    isCoreCCCModule: boolean,
+    expenseGrouping: ExpenseGroupingFieldOption,
+    exportDateType: ExportDateType,
+    { allowPostedAt }: {allowPostedAt?: boolean} = {}
+  ): SelectFormOption[] {
 
     // Determine the excluded date based on expenseGrouping
     const excludedSpendDateOption = [ExpenseGroupingFieldOption.EXPENSE_ID, ExpenseGroupingFieldOption.EXPENSE].includes(expenseGrouping)
@@ -130,7 +135,12 @@ export class ExportSettingModel {
     const excludedApprovedOrVerifiedOption = exportDateType === ExportDateType.APPROVED_AT ? [ExportDateType.VERIFIED_AT] : (exportDateType === ExportDateType.VERIFIED_AT ? [ExportDateType.APPROVED_AT] : [ExportDateType.APPROVED_AT, ExportDateType.VERIFIED_AT]);
 
     // Determine the excluded date based on export Type
-    const excludedPostedAtOption = !isCoreCCCModule ? ExportDateType.POSTED_AT : null;
+    let excludedPostedAtOption = !isCoreCCCModule ? ExportDateType.POSTED_AT : null;
+
+    // Exceptions for users who have already selected posted_at
+    if (allowPostedAt) {
+      excludedPostedAtOption = null;
+    }
 
     // Array of unwanted dates
     const dateOptionsToBeExcluded = [excludedSpendDateOption, excludedPostedAtOption].concat(excludedApprovedOrVerifiedOption);

--- a/src/app/integrations/business-central/business-central-shared/business-central-export-settings/business-central-export-settings.component.ts
+++ b/src/app/integrations/business-central/business-central-shared/business-central-export-settings/business-central-export-settings.component.ts
@@ -160,21 +160,19 @@ export class BusinessCentralExportSettingsComponent implements OnInit {
         this.exportSettingForm.controls.reimbursableExportDate.value
       );
 
-      // If the current selected date option is not in the new options, clear the field
-      const newValues = this.reimbursableExpenseGroupingDateOptions.map((option) => option.value);
-      if (!newValues.includes(this.exportSettingForm.controls.reimbursableExportDate.value)) {
-        this.exportSettingForm.controls.reimbursableExportDate.setValue(null);
-      }
+      ExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('reimbursableExportDate'),
+        this.reimbursableExpenseGroupingDateOptions
+      );
     });
 
     this.exportSettingForm.controls.cccExportGroup.valueChanges.subscribe((cccExportGroup) => {
       this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(true, cccExportGroup, this.exportSettingForm.controls.cccExportDate.value);
 
-      // If the current selected date option is not in the new options, clear the field
-      const newValues = this.cccExpenseGroupingDateOptions.map((option) => option.value);
-      if (!newValues.includes(this.exportSettingForm.controls.cccExportDate.value)) {
-        this.exportSettingForm.controls.cccExportDate.setValue(null);
-      }
+      ExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('cccExportDate'),
+        this.cccExpenseGroupingDateOptions
+      );
     });
 
     this.exportSettingForm.get('reimbursableExportType')?.valueChanges.subscribe(() => this.updateExpenseGroupingValues());

--- a/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.spec.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.spec.ts
@@ -427,25 +427,6 @@ describe('IntacctExportSettingsComponent', () => {
   });
 
   describe('Edge Cases', () => {
-    it('should set the correct CCC expense grouping date options when CCC expense object is unset', () => {
-      component.exportSettings = {
-        configurations: {
-          corporate_credit_card_expenses_object: null
-        }
-      } as ExportSettingGet;
-      spyOn<any>(component, 'setCCExpenseDateOptions');
-
-      component['setupCCCExpenseGroupingDateOptions']();
-      expect(component['setCCExpenseDateOptions']).toHaveBeenCalledOnceWith(IntacctCorporateCreditCardExpensesObject.CHARGE_CARD_TRANSACTION);
-    });
-
-    it('should default CCC expense grouping date options to reimbursable grouping date options for non-charge card transactions', () => {
-      fixture.detectChanges();
-
-      component['setCCExpenseDateOptions'](IntacctCorporateCreditCardExpensesObject.BILL);
-      expect(component.cccExpenseGroupingDateOptions).toEqual(component.reimbursableExpenseGroupingDateOptions);
-    });
-
     it('should set the correct CCC expense grouping date options when grouping by report', () => {
       fixture.detectChanges();
 

--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-export-settings/netsuite-export-settings.component.ts
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-export-settings/netsuite-export-settings.component.ts
@@ -8,7 +8,7 @@ import { ExportSettingModel, ExportSettingOptionSearch } from 'src/app/core/mode
 import { HelperUtility } from 'src/app/core/models/common/helper.model';
 import { SelectFormOption } from 'src/app/core/models/common/select-form-option.model';
 import { DefaultDestinationAttribute, PaginatedDestinationAttribute } from 'src/app/core/models/db/destination-attribute.model';
-import { AppName, ConfigurationCta, ConfigurationWarningEvent, EmployeeFieldMapping, ExpenseGroupingFieldOption, FyleField, NameInJournalEntry, NetSuiteCorporateCreditCardExpensesObject, NetsuiteExportSettingDestinationOptionKey, NetsuiteOnboardingState, NetsuiteReimbursableExpensesObject, ToastSeverity } from 'src/app/core/models/enum/enum.model';
+import { AppName, ConfigurationCta, ConfigurationWarningEvent, EmployeeFieldMapping, ExpenseGroupingFieldOption, ExportDateType, FyleField, NameInJournalEntry, NetSuiteCorporateCreditCardExpensesObject, NetsuiteExportSettingDestinationOptionKey, NetsuiteOnboardingState, NetsuiteReimbursableExpensesObject, ToastSeverity } from 'src/app/core/models/enum/enum.model';
 import { ConfigurationWarningOut } from 'src/app/core/models/misc/configuration-warning.model';
 import { NetSuiteExportSettingGet, NetSuiteExportSettingModel } from 'src/app/core/models/netsuite/netsuite-configuration/netsuite-export-setting.model';
 import { HelperService } from 'src/app/core/services/common/helper.service';
@@ -132,10 +132,6 @@ export class NetsuiteExportSettingsComponent implements OnInit {
 
   refreshDimensions() {
     this.netsuiteHelperServie.refreshNetsuiteDimensions().subscribe();
-  }
-
-  reimbursableExpenseGroupingDate(reimbursableExportGroup: ExpenseGroupingFieldOption, ExpenseGroupingDateOptions: SelectFormOption[]): SelectFormOption[] {
-      return ExportSettingModel.constructGroupingDateOptions(reimbursableExportGroup, ExpenseGroupingDateOptions);
   }
 
   private reimbursableExportTypeWatcher(): void {
@@ -280,14 +276,32 @@ export class NetsuiteExportSettingsComponent implements OnInit {
     this.constructPayloadAndSave({hasAccepted: true, event: ConfigurationWarningEvent.NETSUITE_EXPORT_SETTINGS});
   }
 
-  private updateCCCExpenseGroupingDateOptions(selectedValue: NetSuiteCorporateCreditCardExpensesObject): void {
+  private updateCCCExpenseGroupingDateOptions(
+    selectedValue: NetSuiteCorporateCreditCardExpensesObject,
+    { updateExpenseGroup = true } : {updateExpenseGroup?: boolean} = {}
+  ): void {
     if (selectedValue === NetSuiteCorporateCreditCardExpensesObject.CREDIT_CARD_CHARGE) {
-      this.exportSettingForm.controls.creditCardExportGroup.setValue(ExpenseGroupingFieldOption.EXPENSE_ID);
-      this.exportSettingForm.controls.creditCardExportGroup.disable();
-      this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(true, this.exportSettingForm.controls.creditCardExportGroup.value, this.exportSettingForm.controls.creditCardExportDate.value);
+      if (updateExpenseGroup) {
+        this.exportSettingForm.controls.creditCardExportGroup.setValue(ExpenseGroupingFieldOption.EXPENSE_ID);
+        this.exportSettingForm.controls.creditCardExportGroup.disable();
+      }
+      this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(
+        true,
+        this.exportSettingForm.controls.creditCardExportGroup.value,
+        this.exportSettingForm.controls.creditCardExportDate.value
+      );
     } else {
-      this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(false, this.exportSettingForm.controls.creditCardExportGroup.value, this.exportSettingForm.controls.creditCardExportDate.value);
+      this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(
+        false,
+        this.exportSettingForm.controls.creditCardExportGroup.value,
+        this.exportSettingForm.controls.creditCardExportDate.value
+      );
     }
+
+    ExportSettingModel.clearInvalidDateOption(
+      this.exportSettingForm.get('creditCardExportDate'),
+      this.cccExpenseGroupingDateOptions
+    );
   }
 
   private setupCustomWatchers(): void {
@@ -308,18 +322,22 @@ export class NetsuiteExportSettingsComponent implements OnInit {
 
     this.exportSettingForm.controls.reimbursableExportGroup?.valueChanges.subscribe((reimbursableExportGroup) => {
         this.reimbursableExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(false, reimbursableExportGroup, this.exportSettingForm.controls.reimbursableExportDate.value);
+
+        ExportSettingModel.clearInvalidDateOption(
+          this.exportSettingForm.get('reimbursableExportDate'),
+          this.reimbursableExpenseGroupingDateOptions
+        );
     });
 
     this.exportSettingForm.controls.creditCardExportType.valueChanges.subscribe(creditCardExportType => {
       this.updateCCCExpenseGroupingDateOptions(creditCardExportType);
     });
 
-    this.exportSettingForm.controls.creditCardExportGroup?.valueChanges.subscribe((creditCardExportGroup) => {
-      if (this.exportSettingForm.get('creditCardExportType')?.value && this.exportSettingForm.get('creditCardExportType')?.value !== NetSuiteCorporateCreditCardExpensesObject.CREDIT_CARD_CHARGE) {
-        this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(false, creditCardExportGroup, this.exportSettingForm.controls.creditCardExportDate.value);
-      } else {
-        this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(true, creditCardExportGroup, this.exportSettingForm.controls.creditCardExportDate.value);
-      }
+    this.exportSettingForm.controls.creditCardExportGroup?.valueChanges.subscribe(() => {
+      this.updateCCCExpenseGroupingDateOptions(
+        this.exportSettingForm.get('creditCardExportType')?.value,
+        { updateExpenseGroup: false }
+      );
     });
   }
 

--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-export-settings/netsuite-export-settings.component.ts
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-export-settings/netsuite-export-settings.component.ts
@@ -280,6 +280,17 @@ export class NetsuiteExportSettingsComponent implements OnInit {
     selectedValue: NetSuiteCorporateCreditCardExpensesObject,
     { updateExpenseGroup = true } : {updateExpenseGroup?: boolean} = {}
   ): void {
+
+    // As an exception, show posted_at to orgs that have already selected it outside the core CCC module
+    let cccModuleWithPostedAtDateSelected;
+    if (this.exportSettings.expense_group_settings.ccc_export_date_type === ExportDateType.POSTED_AT) {
+      cccModuleWithPostedAtDateSelected = this.exportSettings.configuration?.corporate_credit_card_expenses_object;
+    }
+
+    const currentCCCModule = this.exportSettingForm.get('creditCardExportType')?.value;
+
+    const allowPostedAt = cccModuleWithPostedAtDateSelected === currentCCCModule;
+
     if (selectedValue === NetSuiteCorporateCreditCardExpensesObject.CREDIT_CARD_CHARGE) {
       if (updateExpenseGroup) {
         this.exportSettingForm.controls.creditCardExportGroup.setValue(ExpenseGroupingFieldOption.EXPENSE_ID);
@@ -288,13 +299,15 @@ export class NetsuiteExportSettingsComponent implements OnInit {
       this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(
         true,
         this.exportSettingForm.controls.creditCardExportGroup.value,
-        this.exportSettingForm.controls.creditCardExportDate.value
+        this.exportSettingForm.controls.creditCardExportDate.value,
+        { allowPostedAt }
       );
     } else {
       this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(
         false,
         this.exportSettingForm.controls.creditCardExportGroup.value,
-        this.exportSettingForm.controls.creditCardExportDate.value
+        this.exportSettingForm.controls.creditCardExportDate.value,
+        { allowPostedAt }
       );
     }
 

--- a/src/app/integrations/qbd-direct/qbd-direct-shared/qbd-direct-export-settings/qbd-direct-export-settings.component.ts
+++ b/src/app/integrations/qbd-direct/qbd-direct-shared/qbd-direct-export-settings/qbd-direct-export-settings.component.ts
@@ -274,16 +274,26 @@ export class QbdDirectExportSettingsComponent implements OnInit{
   reimbursableExpenseGroupWatcher(): void {
     this.exportSettingsForm.controls.reimbursableExportGroup.valueChanges.subscribe((reimbursableExportGroupValue) => {
       this.reimbursableExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(false, reimbursableExportGroupValue, this.exportSettingsForm.controls.reimbursableExportDate.value);
+
+      ExportSettingModel.clearInvalidDateOption(
+        this.exportSettingsForm.get('reimbursableExportDate'),
+        this.reimbursableExpenseGroupingDateOptions
+      );
     });
   }
 
   cccExpenseGroupWatcher(): void {
     this.exportSettingsForm.controls.creditCardExportGroup.valueChanges.subscribe((creditCardExportGroupValue) => {
-      if (this.exportSettingsForm.controls.creditCardExportType.value === QBDCorporateCreditCardExpensesObject.CREDIT_CARD_PURCHASE) {
-        this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(true, creditCardExportGroupValue, this.exportSettingsForm.controls.creditCardExportDate.value);
-      } else {
-        this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(false, creditCardExportGroupValue, this.exportSettingsForm.controls.creditCardExportDate.value);
-      }
+      const isCoreCCCModule = this.exportSettingsForm.controls.creditCardExportType.value === QBDCorporateCreditCardExpensesObject.CREDIT_CARD_PURCHASE;
+
+      this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(
+        isCoreCCCModule, creditCardExportGroupValue, this.exportSettingsForm.controls.creditCardExportDate.value
+      );
+
+      ExportSettingModel.clearInvalidDateOption(
+        this.exportSettingsForm.get('creditCardExportDate'),
+        this.cccExpenseGroupingDateOptions
+      );
     });
   }
 

--- a/src/app/integrations/qbd-direct/qbd-direct-shared/qbd-direct-export-settings/qbd-direct-export-settings.component.ts
+++ b/src/app/integrations/qbd-direct/qbd-direct-shared/qbd-direct-export-settings/qbd-direct-export-settings.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
-import { AppName, ConfigurationCta, EmployeeFieldMapping, ExpenseGroupingFieldOption, Page, ProgressPhase, QBDCorporateCreditCardExpensesObject, QbdDirectExpenseGroupBy, QbdDirectExportSettingDestinationAccountType, QbdDirectExportSettingDestinationOptionKey, QbdDirectOnboardingState, QbdDirectReimbursableExpensesObject, QbdDirectUpdateEvent, QBDExpenseGroupedBy, ToastSeverity, TrackingApp } from 'src/app/core/models/enum/enum.model';
+import { AppName, ConfigurationCta, EmployeeFieldMapping, ExpenseGroupingFieldOption, Page, ProgressPhase, QBDCorporateCreditCardExpensesObject, QbdDirectCCCExportDateType, QbdDirectExpenseGroupBy, QbdDirectExportSettingDestinationAccountType, QbdDirectExportSettingDestinationOptionKey, QbdDirectOnboardingState, QbdDirectReimbursableExpensesObject, QbdDirectUpdateEvent, QBDExpenseGroupedBy, ToastSeverity, TrackingApp } from 'src/app/core/models/enum/enum.model';
 import { QbdDirectExportSettingGet, QbdDirectExportSettingModel } from 'src/app/core/models/qbd-direct/qbd-direct-configuration/qbd-direct-export-settings.model';
 import { IntegrationsToastService } from 'src/app/core/services/common/integrations-toast.service';
 import { TrackingService } from 'src/app/core/services/integration/tracking.service';
@@ -286,8 +286,21 @@ export class QbdDirectExportSettingsComponent implements OnInit{
     this.exportSettingsForm.controls.creditCardExportGroup.valueChanges.subscribe((creditCardExportGroupValue) => {
       const isCoreCCCModule = this.exportSettingsForm.controls.creditCardExportType.value === QBDCorporateCreditCardExpensesObject.CREDIT_CARD_PURCHASE;
 
+      // As an exception, show posted_at to orgs that have already selected it outside the core CCC module
+      let cccModuleWithPostedAtDateSelected;
+      if (this.exportSettings?.credit_card_expense_date === QbdDirectCCCExportDateType.POSTED_AT) {
+        cccModuleWithPostedAtDateSelected = this.exportSettings?.credit_card_expense_export_type;
+      }
+
+      const currentCCCModule = this.exportSettingsForm.get('creditCardExportType')?.value;
+
+      const allowPostedAt = cccModuleWithPostedAtDateSelected === currentCCCModule;
+
       this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(
-        isCoreCCCModule, creditCardExportGroupValue, this.exportSettingsForm.controls.creditCardExportDate.value
+        isCoreCCCModule,
+        creditCardExportGroupValue,
+        this.exportSettingsForm.controls.creditCardExportDate.value,
+        { allowPostedAt }
       );
 
       ExportSettingModel.clearInvalidDateOption(

--- a/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
+++ b/src/app/integrations/qbo/qbo-shared/qbo-export-settings/qbo-export-settings.component.ts
@@ -339,14 +339,30 @@ export class QboExportSettingsComponent implements OnInit {
 
     this.exportSettingForm.controls.reimbursableExportGroup?.valueChanges.subscribe((reimbursableExportGroup) => {
       this.reimbursableExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(false, reimbursableExportGroup, this.exportSettingForm.controls.reimbursableExportDate.value);
+
+      ExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('reimbursableExportDate'),
+        this.reimbursableExpenseGroupingDateOptions
+      );
     });
 
     this.exportSettingForm.controls.creditCardExportGroup?.valueChanges.subscribe((creditCardExportGroup) => {
-      if (this.exportSettingForm.get('creditCardExportType')?.value && this.exportSettingForm.get('creditCardExportType')?.value !== QBOCorporateCreditCardExpensesObject.CREDIT_CARD_PURCHASE && this.exportSettingForm.get('creditCardExportType')?.value !== QBOCorporateCreditCardExpensesObject.DEBIT_CARD_EXPENSE) {
-        this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(false, creditCardExportGroup, this.exportSettingForm.controls.creditCardExportDate.value);
-      } else {
-        this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(true, creditCardExportGroup, this.exportSettingForm.controls.creditCardExportDate.value);
-      }
+
+      // In QBO, credit card purchase and 'debit & credit card expense' are core modules
+      // (Card transaction post date is available for these modules)
+      const isCoreCCCModule = [
+        QBOCorporateCreditCardExpensesObject.CREDIT_CARD_PURCHASE,
+        QBOCorporateCreditCardExpensesObject.DEBIT_CARD_EXPENSE
+      ].includes(this.exportSettingForm.get('creditCardExportType')?.value);
+
+      this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(
+        isCoreCCCModule, creditCardExportGroup, this.exportSettingForm.controls.creditCardExportDate.value
+      );
+
+      ExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('creditCardExportDate'),
+        this.cccExpenseGroupingDateOptions
+      );
     });
   }
 

--- a/src/app/integrations/sage300/sage300-shared/sage300-export-settings/sage300-export-settings.component.ts
+++ b/src/app/integrations/sage300/sage300-shared/sage300-export-settings/sage300-export-settings.component.ts
@@ -123,11 +123,23 @@ export class Sage300ExportSettingsComponent implements OnInit {
     this.exportSettingForm.controls.reimbursableExportGroup?.valueChanges.subscribe((reimbursableExportGroup) => {
       this.reimbursableExpenseGroupingDateOptions = this.exportSettingService.getReimbursableExpenseGroupingDateOptions();
       this.reimbursableExpenseGroupingDateOptions = CommonExportSettingModel.constructGroupingDateOptions(reimbursableExportGroup, this.reimbursableExpenseGroupingDateOptions);
+
+      const validOptions = this.getExportDate(this.reimbursableExpenseGroupingDateOptions, 'reimbursableExportGroup');
+      CommonExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('reimbursableExportDate'),
+        validOptions
+      );
     });
 
     this.exportSettingForm.controls.cccExportGroup?.valueChanges.subscribe((cccExportGroup) => {
       this.cccExpenseGroupingDateOptions = this.exportSettingService.getCCCExpenseGroupingDateOptions();
       this.cccExpenseGroupingDateOptions = CommonExportSettingModel.constructGroupingDateOptions(cccExportGroup, this.cccExpenseGroupingDateOptions);
+
+      const validOptions = this.getExportDate(this.cccExpenseGroupingDateOptions, 'cccExportGroup');
+      CommonExportSettingModel.clearInvalidDateOption(
+        this.exportSettingForm.get('cccExportDate'),
+        validOptions
+      );
     });
   }
 


### PR DESCRIPTION
### Description
If an invalid value remains in the date field while switching export module or export grouping, clear it.

## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced export settings with more precise filtering of export date options based on context and grouping selections.
  - Added automatic clearing of invalid export date selections when grouping options change, ensuring form selections remain valid.

- **Refactor**
  - Centralized and simplified logic for updating and validating export date options across multiple integrations, improving consistency and maintainability.

- **Bug Fixes**
  - Prevented invalid export date selections from persisting after grouping changes, reducing potential form errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->