### PR TITLE
fix: allow a couple exceptions for `posted_at`

### DIFF
--- a/src/app/core/models/common/export-settings.model.ts
+++ b/src/app/core/models/common/export-settings.model.ts
@@ -119,7 +119,12 @@ export class ExportSettingModel {
     ];
   }
 
-  static constructExportDateOptions(isCoreCCCModule: boolean, expenseGrouping: ExpenseGroupingFieldOption, exportDateType: ExportDateType): SelectFormOption[] {
+  static constructExportDateOptions(
+    isCoreCCCModule: boolean,
+    expenseGrouping: ExpenseGroupingFieldOption,
+    exportDateType: ExportDateType,
+    { allowPostedAt }: {allowPostedAt?: boolean} = {}
+  ): SelectFormOption[] {
 
     // Determine the excluded date based on expenseGrouping
     const excludedSpendDateOption = [ExpenseGroupingFieldOption.EXPENSE_ID, ExpenseGroupingFieldOption.EXPENSE].includes(expenseGrouping)
@@ -130,7 +135,12 @@ export class ExportSettingModel {
     const excludedApprovedOrVerifiedOption = exportDateType === ExportDateType.APPROVED_AT ? [ExportDateType.VERIFIED_AT] : (exportDateType === ExportDateType.VERIFIED_AT ? [ExportDateType.APPROVED_AT] : [ExportDateType.APPROVED_AT, ExportDateType.VERIFIED_AT]);
 
     // Determine the excluded date based on export Type
-    const excludedPostedAtOption = !isCoreCCCModule ? ExportDateType.POSTED_AT : null;
+    let excludedPostedAtOption = !isCoreCCCModule ? ExportDateType.POSTED_AT : null;
+
+    // Exceptions for users who have already selected posted_at
+    if (allowPostedAt) {
+      excludedPostedAtOption = null;
+    }
 
     // Array of unwanted dates
     const dateOptionsToBeExcluded = [excludedSpendDateOption, excludedPostedAtOption].concat(excludedApprovedOrVerifiedOption);

--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-export-settings/netsuite-export-settings.component.ts
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-export-settings/netsuite-export-settings.component.ts
@@ -280,6 +280,17 @@ export class NetsuiteExportSettingsComponent implements OnInit {
     selectedValue: NetSuiteCorporateCreditCardExpensesObject,
     { updateExpenseGroup = true } : {updateExpenseGroup?: boolean} = {}
   ): void {
+
+    // As an exception, show posted_at to orgs that have already selected it outside the core CCC module
+    let cccModuleWithPostedAtDateSelected;
+    if (this.exportSettings.expense_group_settings.ccc_export_date_type === ExportDateType.POSTED_AT) {
+      cccModuleWithPostedAtDateSelected = this.exportSettings.configuration?.corporate_credit_card_expenses_object;
+    }
+
+    const currentCCCModule = this.exportSettingForm.get('creditCardExportType')?.value;
+
+    const allowPostedAt = cccModuleWithPostedAtDateSelected === currentCCCModule;
+
     if (selectedValue === NetSuiteCorporateCreditCardExpensesObject.CREDIT_CARD_CHARGE) {
       if (updateExpenseGroup) {
         this.exportSettingForm.controls.creditCardExportGroup.setValue(ExpenseGroupingFieldOption.EXPENSE_ID);
@@ -288,13 +299,15 @@ export class NetsuiteExportSettingsComponent implements OnInit {
       this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(
         true,
         this.exportSettingForm.controls.creditCardExportGroup.value,
-        this.exportSettingForm.controls.creditCardExportDate.value
+        this.exportSettingForm.controls.creditCardExportDate.value,
+        { allowPostedAt }
       );
     } else {
       this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(
         false,
         this.exportSettingForm.controls.creditCardExportGroup.value,
-        this.exportSettingForm.controls.creditCardExportDate.value
+        this.exportSettingForm.controls.creditCardExportDate.value,
+        { allowPostedAt }
       );
     }
 

--- a/src/app/integrations/qbd-direct/qbd-direct-shared/qbd-direct-export-settings/qbd-direct-export-settings.component.ts
+++ b/src/app/integrations/qbd-direct/qbd-direct-shared/qbd-direct-export-settings/qbd-direct-export-settings.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
-import { AppName, ConfigurationCta, EmployeeFieldMapping, ExpenseGroupingFieldOption, Page, ProgressPhase, QBDCorporateCreditCardExpensesObject, QbdDirectExpenseGroupBy, QbdDirectExportSettingDestinationAccountType, QbdDirectExportSettingDestinationOptionKey, QbdDirectOnboardingState, QbdDirectReimbursableExpensesObject, QbdDirectUpdateEvent, QBDExpenseGroupedBy, ToastSeverity, TrackingApp } from 'src/app/core/models/enum/enum.model';
+import { AppName, ConfigurationCta, EmployeeFieldMapping, ExpenseGroupingFieldOption, Page, ProgressPhase, QBDCorporateCreditCardExpensesObject, QbdDirectCCCExportDateType, QbdDirectExpenseGroupBy, QbdDirectExportSettingDestinationAccountType, QbdDirectExportSettingDestinationOptionKey, QbdDirectOnboardingState, QbdDirectReimbursableExpensesObject, QbdDirectUpdateEvent, QBDExpenseGroupedBy, ToastSeverity, TrackingApp } from 'src/app/core/models/enum/enum.model';
 import { QbdDirectExportSettingGet, QbdDirectExportSettingModel } from 'src/app/core/models/qbd-direct/qbd-direct-configuration/qbd-direct-export-settings.model';
 import { IntegrationsToastService } from 'src/app/core/services/common/integrations-toast.service';
 import { TrackingService } from 'src/app/core/services/integration/tracking.service';
@@ -286,8 +286,21 @@ export class QbdDirectExportSettingsComponent implements OnInit{
     this.exportSettingsForm.controls.creditCardExportGroup.valueChanges.subscribe((creditCardExportGroupValue) => {
       const isCoreCCCModule = this.exportSettingsForm.controls.creditCardExportType.value === QBDCorporateCreditCardExpensesObject.CREDIT_CARD_PURCHASE;
 
+      // As an exception, show posted_at to orgs that have already selected it outside the core CCC module
+      let cccModuleWithPostedAtDateSelected;
+      if (this.exportSettings?.credit_card_expense_date === QbdDirectCCCExportDateType.POSTED_AT) {
+        cccModuleWithPostedAtDateSelected = this.exportSettings?.credit_card_expense_export_type;
+      }
+
+      const currentCCCModule = this.exportSettingsForm.get('creditCardExportType')?.value;
+
+      const allowPostedAt = cccModuleWithPostedAtDateSelected === currentCCCModule;
+
       this.cccExpenseGroupingDateOptions = ExportSettingModel.constructExportDateOptions(
-        isCoreCCCModule, creditCardExportGroupValue, this.exportSettingsForm.controls.creditCardExportDate.value
+        isCoreCCCModule,
+        creditCardExportGroupValue,
+        this.exportSettingsForm.controls.creditCardExportDate.value,
+        { allowPostedAt }
       );
 
       ExportSettingModel.clearInvalidDateOption(


### PR DESCRIPTION
### Description
Few orgs have `posted_at` selected with non-core CCC modules. Show the option only for the selected module and only for those orgs.

## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "posted_at" export date option is now conditionally available for certain corporate credit card export settings, allowing organizations with previous selections to retain this option outside the core CCC module.

- **Bug Fixes**
  - Improved handling of export date options to ensure previously selected "posted_at" settings remain visible when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->