### PR TITLE
fix: required fields missing validators

### DIFF
--- a/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-export-settings/intacct-export-settings.component.ts
@@ -300,6 +300,18 @@ export class IntacctExportSettingsComponent implements OnInit {
     }
 
     private createCreditCardExpenseWatcher(): void {
+
+      // If reimbursable expenses are not allowed
+      // -> only credit card expenses are allowed
+      // -> `creditCardExpense` switch is not shown (they're allowed by default)
+      // -> all fields related to credit card expenses are required
+      if (!this.brandingFeatureConfig.featureFlags.exportSettings.reimbursableExpenses) {
+        this.exportSettingsForm.controls.cccExportType.setValidators(Validators.required);
+        this.exportSettingsForm.controls.cccExportGroup.setValidators(Validators.required);
+        this.exportSettingsForm.controls.cccExportDate.setValidators(Validators.required);
+        this.exportSettingsForm.controls.cccExpenseState.setValidators(Validators.required);
+      }
+
       this.exportSettingsForm.controls.creditCardExpense.valueChanges.subscribe((isCreditCardExpenseSelected) => {
         if (isCreditCardExpenseSelected) {
           this.exportSettingsForm.controls.cccExportType.setValidators(Validators.required);


### PR DESCRIPTION
### Description
In C1 > intacct > onboarding > export settings, we never set the `required` validators for the export settings form controls. This meant that empty forms could be submitted during onboarding.

<img width="903" alt="image" src="https://github.com/user-attachments/assets/9d76150b-26e2-47cb-b22b-230a1f51c439" />

## Clickup
https://app.clickup.com/t/86cyvn5d4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Credit card expense fields are now always required when reimbursable expenses are disabled, ensuring proper form validation in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->