### PR TITLE
fix: send `app_name` in Sage 300 > `/expense_attributes` payload

### DIFF
--- a/src/app/core/services/common/mapping.service.ts
+++ b/src/app/core/services/common/mapping.service.ts
@@ -105,7 +105,7 @@ export class MappingService {
     return this.apiService.post(`/workspaces/${this.workspaceService.getWorkspaceId()}/mappings/auto_map_employees/trigger/`, {});
   }
 
-  private getEndpoint(mappingPage: string, isCategoryMappingGeneric?: boolean) {
+  private getEndpoint(mappingPage: string, isCategoryMappingGeneric?: boolean): string {
     if (isCategoryMappingGeneric) {
       return 'expense_attributes';
     }
@@ -122,23 +122,14 @@ export class MappingService {
 
   getGenericMappingsV2(pageLimit: number, pageOffset: number, destinationType: string, mappingState: MappingState, alphabetsFilter: string, sourceType: string, isCategoryMappingGeneric?: boolean, searchQuery? :string | null, appName?: string): Observable<GenericMappingResponse> {
     const workspaceId = this.workspaceService.getWorkspaceId();
-    const endpoint = this.getEndpoint(sourceType, isCategoryMappingGeneric);
-
     const isMapped: boolean = mappingState === MappingState.UNMAPPED ? false : true;
-
-    // For Sage 300, send app_name only for expense_attributes
-    let isAppNameAllowed = !!appName;
-    if (appName === AppName.SAGE300 && endpoint !== 'expense_attributes') {
-      isAppNameAllowed = false;
-    }
-
     const params: GenericMappingApiParams = {
       limit: pageLimit,
       offset: pageOffset,
       mapped: mappingState === MappingState.ALL ? MappingState.ALL : isMapped,
       destination_type: destinationType,
       source_type: sourceType,
-      ...(isAppNameAllowed && { app_name: appName })
+      ...(appName && { app_name: appName })
     };
 
     if (searchQuery) {
@@ -148,6 +139,8 @@ export class MappingService {
     if (alphabetsFilter && alphabetsFilter !== 'All') {
       params.mapping_source_alphabets = alphabetsFilter;
     }
+
+    const endpoint = this.getEndpoint(sourceType, isCategoryMappingGeneric);
 
     return this.apiService.get(`/workspaces/${workspaceId}/mappings/${endpoint}/`, params);
   }

--- a/src/app/shared/components/helper/mapping/generic-mapping-v2/generic-mapping-v2.component.ts
+++ b/src/app/shared/components/helper/mapping/generic-mapping-v2/generic-mapping-v2.component.ts
@@ -161,7 +161,7 @@ export class GenericMappingV2Component implements OnInit {
     this.limit = paginator.limit;
     this.offset = paginator.offset;
     this.sourceType = decodeURIComponent(decodeURIComponent(this.route.snapshot.params.source_field)).toUpperCase();
-    const shouldSendAppName = this.appName === AppName.QBO ? [this.appName] : [];
+    const shouldSendAppName = [AppName.QBO, AppName.SAGE300].includes(this.appName) ? [this.appName] : [];
     forkJoin([
       this.mappingService.getGenericMappingsV2(this.limit, 0, this.destinationField, this.selectedMappingFilter, this.alphabetFilter, this.sourceField, this.isCategoryMappingGeneric, null, ...shouldSendAppName),
       this.mappingService.getMappingStats(this.sourceField, this.destinationField, this.appName)


### PR DESCRIPTION
## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded support for handling app-specific mapping logic to include both QBO and SAGE300 applications in the mapping interface.

- **Bug Fixes**
  - Improved accuracy in sending the app name parameter for API requests, ensuring it is only included when appropriate for SAGE300 and specific endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->