### PR TITLE
refactor: fix compile warning

### DIFF
--- a/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.ts
@@ -46,7 +46,7 @@ export class IntacctC1ImportSettingsComponent implements OnInit {
 
   ConfigurationCtaText = ConfigurationCta;
 
-  importSettings: ImportSettingGet;
+  importSettings?: ImportSettingGet;
 
   sageIntacctFields: ExpenseField[];
 
@@ -349,7 +349,7 @@ export class IntacctC1ImportSettingsComponent implements OnInit {
 
     // First loop to populate mappedFieldMap
     this.sageIntacctFields.forEach((sageIntacctField) => {
-      const mappingSetting = this.importSettings.mapping_settings.find(
+      const mappingSetting = this.importSettings?.mapping_settings.find(
         (setting) => setting.destination_field === sageIntacctField.attribute_type
       );
 
@@ -493,7 +493,7 @@ export class IntacctC1ImportSettingsComponent implements OnInit {
 
   save(): void {
     this.saveInProgress = true;
-    const importSettingPayload = ImportSettings.constructPayload(this.importSettingsForm, this.importSettings.dependent_field_settings);
+    const importSettingPayload = ImportSettings.constructPayload(this.importSettingsForm, this.importSettings!.dependent_field_settings);
     this.importSettingService.postImportSettings(importSettingPayload).subscribe((response: ImportSettingPost) => {
       this.toastService.displayToastMessage(ToastSeverity.SUCCESS, 'Import settings saved successfully');
       this.trackingService.trackTimeSpent(TrackingApp.INTACCT, Page.IMPORT_SETTINGS_INTACCT, this.sessionStartTime);


### PR DESCRIPTION
### Description
Fix this warning
```
Warning: src/app/integrations/intacct/intacct-shared/intacct-c1-import-settings/intacct-c1-import-settings.component.html:53:74 - warning NG8107: The left side of this optional chain operation does not include 'null' or 'undefined' in its type, therefore the '?.' operator can be replaced with the '.' operator.

53         [contextText]="'You have imported cost codes' + (importSettings?.dependent_field_settings?.cost_type_field_name ? ' And cost types' : '') + ' from Sage Intacct by mapping them to fields in ' + brandingConfig.brandName + '. By turning off the import, you would lose the mappings you\'ve established for these fields.'"
                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~
```

## Clickup
app.clickup.com