### PR TITLE
fix: send `app_name` in Sage 300 mapping filter payload

### DIFF
--- a/src/app/shared/components/helper/mapping/generic-mapping-v2/generic-mapping-v2.component.ts
+++ b/src/app/shared/components/helper/mapping/generic-mapping-v2/generic-mapping-v2.component.ts
@@ -106,7 +106,7 @@ export class GenericMappingV2Component implements OnInit {
   }
 
   private getFilteredMappings() {
-    const shouldSendAppName = this.appName === AppName.QBO ? [this.appName] : [];
+    const shouldSendAppName = [AppName.QBO, AppName.SAGE300].includes(this.appName) ? [this.appName] : [];
     this.mappingService.getGenericMappingsV2(this.limit, this.offset, this.destinationField, this.selectedMappingFilter, this.alphabetFilter, this.sourceField, this.isCategoryMappingGeneric, this.searchQuery, ...shouldSendAppName).subscribe((mappingResponse: GenericMappingResponse) => {
       this.filteredMappings = mappingResponse.results.concat();
       this.filteredMappingCount = this.filteredMappings.length;


### PR DESCRIPTION
## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved data retrieval for users of QBO and SAGE300 by updating how application-specific information is handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->