### PR TITLE
fix: typo in xero token guard redirection

### DIFF
--- a/src/app/core/guard/xero-token.guard.ts
+++ b/src/app/core/guard/xero-token.guard.ts
@@ -41,7 +41,7 @@ export class XeroTokenGuard  {
           const onboardingState: XeroOnboardingState = this.workspaceService.getOnboardingState();
           if (onboardingState !== XeroOnboardingState.COMPLETE) {
             this.toastService.displayToastMessage(ToastSeverity.ERROR, 'Oops! your xero connection expired, please connect again');
-            return this.router.navigateByUrl('integrations/qbo/onboarding/connector');
+            return this.router.navigateByUrl('integrations/xero/onboarding/connector');
           }
 
           if (error.error.message === "Xero connection expired"){


### PR DESCRIPTION
## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the redirect behavior to ensure users are sent to the Xero onboarding page instead of the QuickBooks Online onboarding page when the Xero token check fails and onboarding is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->