### PR TITLE
fix: send `app_name` in all mapping page request payloads

### DIFF
--- a/src/app/shared/components/helper/mapping/generic-mapping-v2/generic-mapping-v2.component.ts
+++ b/src/app/shared/components/helper/mapping/generic-mapping-v2/generic-mapping-v2.component.ts
@@ -106,7 +106,7 @@ export class GenericMappingV2Component implements OnInit {
   }
 
   private getFilteredMappings() {
-    const shouldSendAppName = [AppName.QBO, AppName.SAGE300].includes(this.appName) ? [this.appName] : [];
+    const shouldSendAppName = this.appName !== AppName.BUSINESS_CENTRAL ? [this.appName] : [];
     this.mappingService.getGenericMappingsV2(this.limit, this.offset, this.destinationField, this.selectedMappingFilter, this.alphabetFilter, this.sourceField, this.isCategoryMappingGeneric, this.searchQuery, ...shouldSendAppName).subscribe((mappingResponse: GenericMappingResponse) => {
       this.filteredMappings = mappingResponse.results.concat();
       this.filteredMappingCount = this.filteredMappings.length;
@@ -161,7 +161,7 @@ export class GenericMappingV2Component implements OnInit {
     this.limit = paginator.limit;
     this.offset = paginator.offset;
     this.sourceType = decodeURIComponent(decodeURIComponent(this.route.snapshot.params.source_field)).toUpperCase();
-    const shouldSendAppName = [AppName.QBO, AppName.SAGE300].includes(this.appName) ? [this.appName] : [];
+    const shouldSendAppName = this.appName !== AppName.BUSINESS_CENTRAL ? [this.appName] : [];
     forkJoin([
       this.mappingService.getGenericMappingsV2(this.limit, 0, this.destinationField, this.selectedMappingFilter, this.alphabetFilter, this.sourceField, this.isCategoryMappingGeneric, null, ...shouldSendAppName),
       this.mappingService.getMappingStats(this.sourceField, this.destinationField, this.appName)


### PR DESCRIPTION
## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logic for including the app name when retrieving mappings, ensuring broader compatibility across different applications except for BUSINESS_CENTRAL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->