### PR TITLE
fix: turn off real-time export in QBO/Xero

### DIFF
--- a/src/app/core/models/qbo/qbo-configuration/qbo-advanced-setting.model.ts
+++ b/src/app/core/models/qbo/qbo-configuration/qbo-advanced-setting.model.ts
@@ -142,7 +142,7 @@ export class QBOAdvancedSettingModel extends HelperUtility {
       workspace_schedules: {
         enabled: advancedSettingsForm.get('exportSchedule')?.value ? true : false,
         interval_hours: Number.isInteger(advancedSettingsForm.get('exportScheduleFrequency')?.value) ? advancedSettingsForm.get('exportScheduleFrequency')!.value : null,
-        is_real_time_export_enabled: advancedSettingsForm.get('exportScheduleFrequency')?.value === 0 ? true : false,
+        is_real_time_export_enabled: advancedSettingsForm.get('exportSchedule')?.value && advancedSettingsForm.get('exportScheduleFrequency')?.value === 0 ? true : false,
         emails_selected: advancedSettingsForm.get('email')?.value ? AdvancedSettingsModel.formatSelectedEmails(advancedSettingsForm.get('email')?.value) : null,
         additional_email_options: advancedSettingsForm.get('additionalEmails')?.value ? advancedSettingsForm.get('additionalEmails')?.value[0] : null
       }

--- a/src/app/core/models/xero/xero-configuration/xero-advanced-settings.model.ts
+++ b/src/app/core/models/xero/xero-configuration/xero-advanced-settings.model.ts
@@ -159,7 +159,7 @@ export class XeroAdvancedSettingModel extends HelperUtility{
       workspace_schedules: {
         enabled: advancedSettingsForm.get('exportSchedule')?.value ? true : false,
         interval_hours: Number.isInteger(advancedSettingsForm.get('exportScheduleFrequency')?.value) ? advancedSettingsForm.get('exportScheduleFrequency')!.value : null,
-        is_real_time_export_enabled: advancedSettingsForm.get('exportScheduleFrequency')?.value === 0 ? true : false,
+        is_real_time_export_enabled: advancedSettingsForm.get('exportSchedule')?.value && advancedSettingsForm.get('exportScheduleFrequency')?.value === 0 ? true : false,
         start_datetime: new Date(),
         emails_selected: advancedSettingsForm.get('email')?.value ? AdvancedSettingsModel.formatSelectedEmails(advancedSettingsForm.get('email')?.value) : [],
         additional_email_options: advancedSettingsForm.get('additionalEmails')?.value ? advancedSettingsForm.get('additionalEmails')?.value : []


### PR DESCRIPTION
### Description
Please add PR description here, add screenshots if needed

## Clickup
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for enabling real-time export, ensuring it is only activated when the export schedule is enabled and set to immediate frequency. This prevents real-time export from being enabled unintentionally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->