### PR TITLE
fix: show the expense / report number option based on the current grouping

### DIFF
--- a/src/app/branding/c1-branding-config.ts
+++ b/src/app/branding/c1-branding-config.ts
@@ -55,7 +55,8 @@ export const c1FeatureConfig: FeatureConfiguration[string] = {
             autoCreateContacts: false,
             useEmployeeAttributes: true,
             autoCreateMerchants: true,
-            excludeCardNumberAndEmployeeNameInMemo: true
+            excludeCardNumberAndEmployeeNameInMemo: true,
+            showTopLevelMemoFieldInIntacct: false
         },
         exportLog: {
             expenseType: false

--- a/src/app/branding/fyle-branding-config.ts
+++ b/src/app/branding/fyle-branding-config.ts
@@ -55,7 +55,8 @@ export const fyleFeatureConfig: FeatureConfiguration[string] = {
             autoCreateContacts: true,
             useEmployeeAttributes: true,
             autoCreateMerchants: true,
-            excludeCardNumberAndEmployeeNameInMemo: false
+            excludeCardNumberAndEmployeeNameInMemo: false,
+            showTopLevelMemoFieldInIntacct: true
         },
         exportLog: {
             expenseType: true

--- a/src/app/core/models/branding/feature-configuration.model.ts
+++ b/src/app/core/models/branding/feature-configuration.model.ts
@@ -49,6 +49,7 @@ export type FeatureConfiguration = {
                 useEmployeeAttributes: boolean;
                 autoCreateMerchants: boolean;
                 excludeCardNumberAndEmployeeNameInMemo: boolean;
+                showTopLevelMemoFieldInIntacct: boolean;
             },
             exportLog: {
                 expenseType: boolean;

--- a/src/app/core/models/common/advanced-settings.model.ts
+++ b/src/app/core/models/common/advanced-settings.model.ts
@@ -1,5 +1,5 @@
 import { FormControl, FormGroup } from "@angular/forms";
-import { AppName, JoinOption, Operator } from "../enum/enum.model";
+import { AppName, ExpenseGroupingFieldOption, JoinOption, Operator } from "../enum/enum.model";
 import { environment } from "src/environments/environment";
 import { ExportSettingGet } from "../intacct/intacct-configuration/export-settings.model";
 import { QBOExportSettingGet } from "../qbo/qbo-configuration/qbo-export-setting.model";
@@ -113,6 +113,41 @@ export class AdvancedSettingsModel {
 
   }
 
+  /**
+   * Returns the top level memo options based on whether expenses are grouped by report
+   * @returns string[]
+   */
+  static getTopLevelMemoOptions(reimbursableGroupedBy?: ExpenseGroupingFieldOption, cccGroupedBy?: ExpenseGroupingFieldOption): string[] {
+    let options = this.getDefaultTopMemoOptions();
+    // Exclude employee name from the top level memo options if the feature flag is enabled
+    if (brandingFeatureConfig.featureFlags.advancedSettings.excludeCardNumberAndEmployeeNameInMemo) {
+      options = options.filter(option => option !== 'employee_name');
+    }
+
+    let finalOption;
+    if (reimbursableGroupedBy === cccGroupedBy) {
+      // If reimbursable and ccc are grouped by the same field, then the top level memo option is the field name
+      // ('Expense number' or 'Report number')
+      if (reimbursableGroupedBy === ExpenseGroupingFieldOption.EXPENSE_ID) {
+        finalOption = 'expense_number';
+      } else {
+        finalOption = 'report_number';
+      }
+    } else if (reimbursableGroupedBy === undefined) {
+      // If reimbursable is not grouped, then the top level memo option is the ccc field name
+      finalOption = cccGroupedBy === ExpenseGroupingFieldOption.EXPENSE_ID ? 'expense_number' : 'report_number';
+    } else if (cccGroupedBy === undefined) {
+      // If ccc is not grouped, then the top level memo option is the reimbursable field name
+      finalOption = reimbursableGroupedBy === ExpenseGroupingFieldOption.EXPENSE_ID ? 'expense_number' : 'report_number';
+    } else {
+      // If reimbursable and ccc are grouped by different fields, then default the top level memo option to report number
+      finalOption = 'report_number';
+    }
+
+    options[options.length - 1] = finalOption;
+    return options;
+  }
+
   static formatMemoPreview(memoStructure: string[], defaultMemoOptions: string[]): [string, string[]] {
     const time = Date.now();
     const today = new Date(time);
@@ -127,6 +162,7 @@ export class AdvancedSettingsModel {
       report_number: 'C/2021/12/R/1',
       spent_on: today.toLocaleDateString(),
       expense_key: 'E/2024/02/T/11',
+      expense_number: 'E/2024/02/T/11',
       expense_link: `${environment.fyle_app_url}/app/main/#/enterprise/view_expense/`
     };
     let memoPreviewText = '';

--- a/src/app/integrations/intacct/intacct-shared/intacct-advanced-settings/intacct-advanced-settings.component.html
+++ b/src/app/integrations/intacct/intacct-shared/intacct-advanced-settings/intacct-advanced-settings.component.html
@@ -121,6 +121,24 @@
                 [label]="'Customization'"
                 [subLabel]="brandingContent.intacct.configuration.advancedSettings.customizeSectionSubLabel">
             </app-configuration-step-sub-header>
+            @if (brandingFeatureConfig.featureFlags.advancedSettings.showTopLevelMemoFieldInIntacct) {
+                <div class="tw-mt-16-px tw-bg-white tw-border tw-border-solid tw-border-separator tw-rounded-12-px">
+                    <app-configuration-multi-select
+                    [form]="advancedSettingsForm"
+                    [label]="brandingContent.intacct.configuration.advancedSettings.setTopMemoField"
+                    [subLabel]="brandingContent.intacct.configuration.advancedSettings.topMemoStructureSubLabel"
+                    [options]="defaultTopMemoFields"
+                    [iconPath]="'list'"
+                    [placeholder]="'Select top memo'"
+                    [formControllerName]="'setTopMemoField'"></app-configuration-multi-select>
+                    <div class="tw-pl-60-px tw-pr-24-px tw-pb-24-px">
+                        <p class="tw-text-form-label-text-color tw-text-14-px tw-mb-12-px">Preview {{brandingContent.intacct.common.descriptionText}}</p>
+                        <div class="tw-bg-disabled-bg-color tw-rounded-4-px tw-text-14-px tw-py-10-px tw-px-16-px tw-text-text-muted tw-min-h-40-px">
+                            <span>{{ topMemoPreviewText }}</span>
+                        </div>
+                    </div>
+                </div>
+            }
             <div class="tw-mt-16-px tw-bg-white tw-border tw-border-solid tw-border-separator tw-rounded-12-px">
                 <app-configuration-multi-select
                 [form]="advancedSettingsForm"
@@ -132,24 +150,8 @@
                 [formControllerName]="'setDescriptionField'"></app-configuration-multi-select>
                 <div class="tw-pl-60-px tw-pr-24-px tw-pb-24-px">
                     <p class="tw-text-form-label-text-color tw-text-14-px tw-mb-12-px">Preview {{brandingContent.intacct.common.descriptionText}}</p>
-                    <div class="tw-bg-disabled-bg-color tw-rounded-4-px tw-text-14-px tw-py-10-px tw-px-16-px tw-text-text-muted">
+                    <div class="tw-bg-disabled-bg-color tw-rounded-4-px tw-text-14-px tw-py-10-px tw-px-16-px tw-text-text-muted tw-min-h-40-px">
                         <span>{{ memoPreviewText }}</span>
-                    </div>
-                </div>
-            </div>
-            <div class="tw-mt-16-px tw-bg-white tw-border tw-border-solid tw-border-separator tw-rounded-12-px">
-                <app-configuration-multi-select
-                [form]="advancedSettingsForm"
-                [label]="brandingContent.intacct.configuration.advancedSettings.setTopMemoField"
-                [subLabel]="brandingContent.intacct.configuration.advancedSettings.topMemoStructureSubLabel"
-                [options]="defaultTopMemoFields"
-                [iconPath]="'list'"
-                [placeholder]="'Select top memo'"
-                [formControllerName]="'setTopMemoField'"></app-configuration-multi-select>
-                <div class="tw-pl-60-px tw-pr-24-px tw-pb-24-px">
-                    <p class="tw-text-form-label-text-color tw-text-14-px tw-mb-12-px">Preview {{brandingContent.intacct.common.descriptionText}}</p>
-                    <div class="tw-bg-disabled-bg-color tw-rounded-4-px tw-text-14-px tw-py-10-px tw-px-16-px tw-text-text-muted">
-                        <span>{{ topMemoPreviewText }}</span>
                     </div>
                 </div>
             </div>

--- a/src/app/integrations/intacct/intacct-shared/intacct-advanced-settings/intacct-advanced-settings.component.spec.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-advanced-settings/intacct-advanced-settings.component.spec.ts
@@ -145,7 +145,6 @@ describe('IntacctAdvancedSettingsComponent', () => {
       component.advancedSettingsForm.get('setDescriptionField')?.setValue(newMemoStructure);
       tick();
 
-      expect(component.memoStructure).toEqual(newMemoStructure);
       expect(component.memoPreviewText).toBe('Client Meeting - Meals and Entertainment - ' + new Date(Date.now()).toLocaleDateString());
     }));
 

--- a/src/app/integrations/intacct/intacct-shared/intacct-advanced-settings/intacct-advanced-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-advanced-settings/intacct-advanced-settings.component.ts
@@ -103,7 +103,7 @@ export class IntacctAdvancedSettingsComponent implements OnInit {
 
   defaultMemoFields: string[] = AdvancedSettingsModel.getDefaultMemoOptions();
 
-  defaultTopMemoFields: string[] = AdvancedSettingsModel.getDefaultTopMemoOptions();
+  defaultTopMemoFields: string[];
 
   paymentSyncOptions: AdvancedSettingFormOption[] = [
     {
@@ -322,6 +322,14 @@ export class IntacctAdvancedSettingsComponent implements OnInit {
           this.adminEmails = this.adminEmails.concat(this.advancedSettings.workspace_schedules?.additional_email_options);
         }
         this.defaultMemoFields = AdvancedSettingsModel.getMemoOptions(configuration, AppName.INTACCT);
+
+        const isReimbursableEnabled = exportSettings.configurations.reimbursable_expenses_object;
+        const isCCCEnabled = exportSettings.configurations.corporate_credit_card_expenses_object;
+
+        this.defaultTopMemoFields = AdvancedSettingsModel.getTopLevelMemoOptions(
+          isReimbursableEnabled ? this.reimbursableExportGroup : undefined,
+          isCCCEnabled ? this.cccExportGroup : undefined
+        );
         this.initializeAdvancedSettingsFormWithData(!!expenseFilter.count);
         this.initializeSkipExportForm();
         this.isLoading = false;

--- a/src/app/integrations/intacct/intacct-shared/intacct-advanced-settings/intacct-advanced-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-advanced-settings/intacct-advanced-settings.component.ts
@@ -60,8 +60,6 @@ export class IntacctAdvancedSettingsComponent implements OnInit {
 
   hours: SelectFormOption[] = AdvancedSettingsModel.getHoursOptions();
 
-  memoStructure: string[] = [];
-
   sageIntacctLocations: IntacctDestinationAttribute[];
 
   sageIntacctDepartments: IntacctDestinationAttribute[];
@@ -214,6 +212,20 @@ export class IntacctAdvancedSettingsComponent implements OnInit {
 
   private initializeAdvancedSettingsFormWithData(isSkippedExpense: boolean): void {
     const findObjectByDestinationId = (array: IntacctDestinationAttribute[], id: string) => array?.find(item => item.destination_id === id) || null;
+
+    const topLevelMemoFieldValue = this.advancedSettings.configurations.top_level_memo_structure;
+    if (topLevelMemoFieldValue) {
+      for (let i = 0; i < topLevelMemoFieldValue.length; i++) {
+        const currentOption = topLevelMemoFieldValue[i];
+        const expenseOrReportNumberOptions = ['expense_number', 'report_number'];
+
+        // If expense number or report number was previously selected when it is not a valid option anymore, swap it
+        if (expenseOrReportNumberOptions.includes(currentOption) && !this.defaultTopMemoFields.includes(currentOption)) {
+          topLevelMemoFieldValue[i] = currentOption === 'expense_number' ? 'report_number' : 'expense_number';
+        }
+      }
+    }
+
     this.advancedSettingsForm = this.formBuilder.group({
       exportSchedule: new FormControl(this.advancedSettings.workspace_schedules?.enabled || (this.isOnboarding && brandingFeatureConfig.featureFlags.dashboard.useRepurposedExportSummary) ? true : false),
       exportScheduleFrequency: new FormControl(AdvancedSettingsModel.getExportFrequency(this.advancedSettings.workspace_schedules?.is_real_time_export_enabled, this.isOnboarding, this.advancedSettings.workspace_schedules?.enabled, this.advancedSettings.workspace_schedules?.interval_hours)),
@@ -225,7 +237,7 @@ export class IntacctAdvancedSettingsComponent implements OnInit {
       autoCreateEmployeeVendor: [this.advancedSettings.configurations.auto_create_destination_entity],
       postEntriesCurrentPeriod: [this.advancedSettings.configurations.change_accounting_period ? true : false],
       setDescriptionField: [this.advancedSettings.configurations.memo_structure ? this.advancedSettings.configurations.memo_structure : this.defaultMemoFields, Validators.required],
-      setTopMemoField: [this.advancedSettings.configurations.top_level_memo_structure ? this.advancedSettings.configurations.top_level_memo_structure : this.defaultTopMemoFields],
+      setTopMemoField: [topLevelMemoFieldValue ? topLevelMemoFieldValue : []],
       skipSelectiveExpenses: [isSkippedExpense],
       defaultLocation: [findObjectByDestinationId(this.sageIntacctLocations, this.advancedSettings.general_mappings.default_location.id)],
       defaultDepartment: [findObjectByDestinationId(this.sageIntacctDepartments, this.advancedSettings.general_mappings.default_department.id)],


### PR DESCRIPTION
### Description
In the custom top-level memo field, show 'Expense number' / 'Report number' as follows:
1. If CCC and reimbursable are both grouped by the same thing, show that option (eg: if both are grouped by report, show 'Report number')
2. If only one of the two are enabled, show 'Expense number' / 'Report number' based on the selected expense grouping
3. If CCC and reimbursable expenses are grouped differently, show 'Report number'

## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Memo field options in advanced settings are now dynamically generated based on your current export configuration.
  - Added a new preview value for the 'expense_number' memo option.

- **Bug Fixes**
  - Improved accuracy of top-level memo options when grouping reimbursable and corporate credit card expenses differently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->