### PR TITLE
fix: invalidate old expense/report number option in top level memo field

### DIFF
--- a/src/app/integrations/intacct/intacct-shared/intacct-advanced-settings/intacct-advanced-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-advanced-settings/intacct-advanced-settings.component.ts
@@ -212,6 +212,20 @@ export class IntacctAdvancedSettingsComponent implements OnInit {
 
   private initializeAdvancedSettingsFormWithData(isSkippedExpense: boolean): void {
     const findObjectByDestinationId = (array: IntacctDestinationAttribute[], id: string) => array?.find(item => item.destination_id === id) || null;
+
+    const topLevelMemoFieldValue = this.advancedSettings.configurations.top_level_memo_structure;
+    if (topLevelMemoFieldValue) {
+      for (let i = 0; i < topLevelMemoFieldValue.length; i++) {
+        const currentOption = topLevelMemoFieldValue[i];
+        const expenseOrReportNumberOptions = ['expense_number', 'report_number'];
+
+        // If expense number or report number was previously selected when it is not a valid option anymore, swap it
+        if (expenseOrReportNumberOptions.includes(currentOption) && !this.defaultTopMemoFields.includes(currentOption)) {
+          topLevelMemoFieldValue[i] = currentOption === 'expense_number' ? 'report_number' : 'expense_number';
+        }
+      }
+    }
+
     this.advancedSettingsForm = this.formBuilder.group({
       exportSchedule: new FormControl(this.advancedSettings.workspace_schedules?.enabled || (this.isOnboarding && brandingFeatureConfig.featureFlags.dashboard.useRepurposedExportSummary) ? true : false),
       exportScheduleFrequency: new FormControl(AdvancedSettingsModel.getExportFrequency(this.advancedSettings.workspace_schedules?.is_real_time_export_enabled, this.isOnboarding, this.advancedSettings.workspace_schedules?.enabled, this.advancedSettings.workspace_schedules?.interval_hours)),
@@ -223,7 +237,7 @@ export class IntacctAdvancedSettingsComponent implements OnInit {
       autoCreateEmployeeVendor: [this.advancedSettings.configurations.auto_create_destination_entity],
       postEntriesCurrentPeriod: [this.advancedSettings.configurations.change_accounting_period ? true : false],
       setDescriptionField: [this.advancedSettings.configurations.memo_structure ? this.advancedSettings.configurations.memo_structure : this.defaultMemoFields, Validators.required],
-      setTopMemoField: [this.advancedSettings.configurations.top_level_memo_structure ? this.advancedSettings.configurations.top_level_memo_structure : []],
+      setTopMemoField: [topLevelMemoFieldValue ? topLevelMemoFieldValue : []],
       skipSelectiveExpenses: [isSkippedExpense],
       defaultLocation: [findObjectByDestinationId(this.sageIntacctLocations, this.advancedSettings.general_mappings.default_location.id)],
       defaultDepartment: [findObjectByDestinationId(this.sageIntacctDepartments, this.advancedSettings.general_mappings.default_department.id)],


### PR DESCRIPTION
### Description
Fixes this case:
1. Group expenses by report
2. Select 'Report number' in the top level memo field
3. Change grouping to expense number
4. 'Report number' is still the selected value when it should be 'Expense number'

## Clickup
app.clickup.com