### PR TITLE
fix: locale date format bug and timezone bug

### DIFF
--- a/src/app/core/services/common/export-log.service.ts
+++ b/src/app/core/services/common/export-log.service.ts
@@ -70,13 +70,11 @@ export class ExportLogService {
     }
 
     if (selectedDateFilter) {
-      const startDate = selectedDateFilter.startDate.toLocaleDateString().split('/');
-      const endDate = selectedDateFilter.endDate.toLocaleDateString().split('/');
-
-      const dateFormat = `${startDate[2]}-${startDate[1]}-${startDate[0]}`;
+      const {startDate, endDate} = selectedDateFilter;
+      endDate.setHours(23, 59, 59);
       const dateRange = {
-        start: `${dateFormat}T00:00:00`,
-        end: `${endDate[2]}-${endDate[1]}-${endDate[0]}T23:59:59`
+        start: `${startDate.getUTCFullYear()}-${startDate.getUTCMonth() + 1}-${startDate.getUTCDate()}T${startDate.getUTCHours()}:${startDate.getUTCMinutes()}:${startDate.getUTCSeconds()}`,
+        end: `${endDate.getUTCFullYear()}-${endDate.getUTCMonth() + 1}-${endDate.getUTCDate()}T${endDate.getUTCHours()}:${endDate.getUTCMinutes()}:${endDate.getUTCSeconds()}`
       };
 
       if (state === TaskLogState.COMPLETE) {


### PR DESCRIPTION
### Description
`toLocaleDateString` converts dates in different formats depending on the user's locale:

en-US: "12/20/2012"
en-GB: "20/12/2012"

This would fail for users with the en-US locale since we are assuming day-month-year order.

Also fixed a timezone issue, where users were shown expense groups from ±1 day. This was happening since we were sending date filters in the local timezone when the endpoint is expecting it in UTC.

## Clickup
https://app.clickup.com/t/86cz6aakf