### PR TITLE
fix: qbd direct assisted setup article link changes

### DIFF
--- a/src/app/branding/c1-branding-config.ts
+++ b/src/app/branding/c1-branding-config.ts
@@ -141,6 +141,7 @@ export const c1KbArticles: KbArticle[string] = {
             EXPORT_SETTING: `${brandingConfig.helpArticleDomain}/en/articles/9082146-configure-the-capital-one-sage-intacct-integration#h_eebe5df4b7`,
             ADVANCED_SETTING: `${brandingConfig.helpArticleDomain}/en/articles/9082146-configure-the-capital-one-sage-intacct-integration#h_498f2acc61`,
             CONNECTOR: `${brandingConfig.helpArticleDomain}/en/articles/10259583-quickbooks-desktop-integration-beta#h_d3cc42849a`,
+            ASSISTED_SETUP_ARTICLE_LINK: `${brandingConfig.helpArticleDomain}/en/articles/10259583-quickbooks-desktop-integration`,
             HELPER_ARTICLE: `${brandingConfig.helpArticleDomain}/en/articles/7882821-how-to-skip-exporting-specific-expenses-from-fyle-to-sage-intacct`,
             GCAL_LINK: `https://calendar.app.google/xRwaKsiwEYukqigx9`
         }

--- a/src/app/branding/fyle-branding-config.ts
+++ b/src/app/branding/fyle-branding-config.ts
@@ -142,6 +142,7 @@ export const fyleKbArticles: KbArticle[string] = {
             EXPORT_SETTING: `${brandingConfig.helpArticleDomain}/en/articles/10259583-quickbooks-desktop-integration-beta#h_1366df4107`,
             ADVANCED_SETTING: `${brandingConfig.helpArticleDomain}/en/articles/10259583-quickbooks-desktop-integration-beta#h_b3850646c0`,
             CONNECTOR: `${brandingConfig.helpArticleDomain}/en/articles/10259583-quickbooks-desktop-integration-beta#h_d3cc42849a`,
+            ASSISTED_SETUP_ARTICLE_LINK: `${brandingConfig.helpArticleDomain}/en/articles/10259583-quickbooks-desktop-integration`,
             HELPER_ARTICLE: `${brandingConfig.helpArticleDomain}/en/articles/10259583-quickbooks-desktop-integration#h_d3cc42849a`,
             GCAL_LINK: `https://calendar.app.google/xRwaKsiwEYukqigx9`
         }

--- a/src/app/core/models/branding/kb-article.model.ts
+++ b/src/app/core/models/branding/kb-article.model.ts
@@ -18,6 +18,7 @@ export type KbArticle = {
                 EXPORT_SETTING: string;
                 ADVANCED_SETTING: string;
                 CONNECTOR: string;
+                ASSISTED_SETUP_ARTICLE_LINK: string;
                 HELPER_ARTICLE: string;
                 GCAL_LINK: string;
             },

--- a/src/app/integrations/qbd-direct/qbd-direct-shared/qbd-direct-assisted-setup/qbd-direct-assisted-setup.component.ts
+++ b/src/app/integrations/qbd-direct/qbd-direct-shared/qbd-direct-assisted-setup/qbd-direct-assisted-setup.component.ts
@@ -76,7 +76,7 @@ constructor(
   }
 
   openQBDArticle(): void {
-    this.nativeWindow.open(brandingKbArticles.onboardingArticles.QBD_DIRECT.CONNECTOR, '_blank');
+    this.nativeWindow.open(brandingKbArticles.onboardingArticles.QBD_DIRECT.ASSISTED_SETUP_ARTICLE_LINK, '_blank');
   }
 
   bookSlot(): void {


### PR DESCRIPTION
### Description
qbd direct assisted setup article link changes

## Clickup
[Please add link here](https://app.clickup.com/1864988/v/l/6-901608415208-1?pr=61205553)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new help article link for QuickBooks Desktop integration, accessible during the assisted setup process.
  - The assisted setup now opens a dedicated article for QuickBooks Desktop integration in a new browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->