### PR TITLE
fix(e2e): add roles to intacct import settings switches

### DIFF
--- a/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.html
+++ b/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.html
@@ -34,7 +34,7 @@
         </div>
         <div class="tw-flex tw-pt-18-px">
             <div class="tw-pl-48-px">
-                <input type="text" class="tw-text-14-px tw-text-slightly-normal-text-color !tw-font-500 tw-w-300-px !tw-px-14-px !tw-py-10-px tw-border tw-border-solid !tw-border-separator tw-rounded-4-px" value="{{(intacctCategoryDestination | snakeCaseToSpaceCase | sentenceCase).replace('Gl ', 'GL ')}}" disabled>
+                <input type="text" class="tw-text-14-px tw-text-slightly-normal-text-color !tw-font-500 tw-w-300-px !tw-px-14-px !tw-py-10-px tw-border tw-border-solid !tw-border-separator tw-rounded-4-px" [value]="intacctCategoryDestinationLabel" disabled>
             </div>
             <div class="tw-pt-16-px ">
                 <app-svg-icon [isTextColorAllowed]="true" [svgSource]="'arrow-line'" [height]="'30px'" [width]="'100px'" [styleClasses]="'!tw-ml-0 tw-text-box-color'"></app-svg-icon>
@@ -43,7 +43,7 @@
                 <input type="text" class="tw-text-14-px tw-text-slightly-normal-text-color !tw-font-500 tw-w-300-px !tw-px-14-px !tw-py-10-px tw-border tw-border-solid !tw-border-separator tw-rounded-4-px" value="Category" disabled>
             </div>
             <div class="input-toggle-section tw-w-10-vw">
-                <p-inputSwitch formControlName="importCategories" (onChange)="addImportCodeField($event, intacctCategoryDestination)"></p-inputSwitch>
+                <p-inputSwitch formControlName="importCategories" [attr.aria-label]="'Import ' + intacctCategoryDestinationLabel + 's as categories'" (onChange)="addImportCodeField($event, intacctCategoryDestination)"></p-inputSwitch>
             </div>
         </div>
         <div class="tw-flex tw-pt-18-px">
@@ -57,7 +57,7 @@
                 <input type="text" class="tw-text-14-px tw-text-slightly-normal-text-color !tw-font-500 tw-w-300-px !tw-px-14-px !tw-py-10-px tw-border tw-border-solid !tw-border-separator tw-rounded-4-px" value="Merchant" disabled>
             </span>
             <span class="input-toggle-section tw-w-10-vw">
-                <p-inputSwitch formControlName="importVendorAsMerchant"></p-inputSwitch>
+                <p-inputSwitch formControlName="importVendorAsMerchant" aria-label="Import vendor as merchant"></p-inputSwitch>
             </span>
         </div>
         <div class="tw-flex tw-pt-18-px" *ngIf="isImportTaxVisible">
@@ -71,7 +71,7 @@
                 <input type="text" class="tw-text-14-px tw-text-slightly-normal-text-color !tw-font-500 tw-w-300-px !tw-px-14-px !tw-py-10-px tw-border tw-border-solid !tw-border-separator tw-rounded-4-px" value="Tax group" disabled>
             </span>
             <span class="input-toggle-section tw-w-10-vw">
-                <p-inputSwitch formControlName="importTaxCodes"></p-inputSwitch>
+                <p-inputSwitch formControlName="importTaxCodes" aria-label="Import tax codes"></p-inputSwitch>
             </span>
         </div>
         <div class="tw-flex tw-pl-48-px tw-pt-18-px" *ngIf="importSettingsForm.get('importTaxCodes')?.value && isImportTaxVisible">
@@ -162,7 +162,7 @@
                                     </div>
                                 </ng-template>
                             </p-dropdown>
-                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costCodesImportToggle" [disabled]="true"></p-inputSwitch>
+                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costCodesImportToggle" [disabled]="true" aria-label="Import cost codes"></p-inputSwitch>
                         </div>
                         <div class="tw-flex tw-pt-4" *ngIf="importSettingsForm.get('isDependentImportEnabled')?.value">
                             <div>
@@ -180,7 +180,7 @@
                                         {{ option.display_name }}                                    </div>
                                   </ng-template>
                             </p-dropdown>
-                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costTypesImportToggle" [disabled]="true"></p-inputSwitch>
+                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costTypesImportToggle" [disabled]="true" aria-label="Import cost types"></p-inputSwitch>
                         </div>
                     </div>
                 </div>

--- a/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.html
+++ b/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.html
@@ -43,7 +43,7 @@
                 <input type="text" class="tw-text-14-px tw-text-slightly-normal-text-color !tw-font-500 tw-w-300-px !tw-px-14-px !tw-py-10-px tw-border tw-border-solid !tw-border-separator tw-rounded-4-px" value="Category" disabled>
             </div>
             <div class="input-toggle-section tw-w-10-vw">
-                <p-inputSwitch formControlName="importCategories" [attr.aria-label]="'Import ' + intacctCategoryDestinationLabel + 's as categories'" (onChange)="addImportCodeField($event, intacctCategoryDestination)"></p-inputSwitch>
+                <p-inputSwitch formControlName="importCategories" [attr.aria-label]="'Import ' + intacctCategoryDestinationLabel + 's as categories'" role="switch" (onChange)="addImportCodeField($event, intacctCategoryDestination)"></p-inputSwitch>
             </div>
         </div>
         <div class="tw-flex tw-pt-18-px">
@@ -57,7 +57,7 @@
                 <input type="text" class="tw-text-14-px tw-text-slightly-normal-text-color !tw-font-500 tw-w-300-px !tw-px-14-px !tw-py-10-px tw-border tw-border-solid !tw-border-separator tw-rounded-4-px" value="Merchant" disabled>
             </span>
             <span class="input-toggle-section tw-w-10-vw">
-                <p-inputSwitch formControlName="importVendorAsMerchant" aria-label="Import vendor as merchant"></p-inputSwitch>
+                <p-inputSwitch formControlName="importVendorAsMerchant" aria-label="Import vendor as merchant" role="switch"></p-inputSwitch>
             </span>
         </div>
         <div class="tw-flex tw-pt-18-px" *ngIf="isImportTaxVisible">
@@ -71,7 +71,7 @@
                 <input type="text" class="tw-text-14-px tw-text-slightly-normal-text-color !tw-font-500 tw-w-300-px !tw-px-14-px !tw-py-10-px tw-border tw-border-solid !tw-border-separator tw-rounded-4-px" value="Tax group" disabled>
             </span>
             <span class="input-toggle-section tw-w-10-vw">
-                <p-inputSwitch formControlName="importTaxCodes" aria-label="Import tax codes"></p-inputSwitch>
+                <p-inputSwitch formControlName="importTaxCodes" aria-label="Import tax codes" role="switch"></p-inputSwitch>
             </span>
         </div>
         <div class="tw-flex tw-pl-48-px tw-pt-18-px" *ngIf="importSettingsForm.get('importTaxCodes')?.value && isImportTaxVisible">
@@ -162,7 +162,7 @@
                                     </div>
                                 </ng-template>
                             </p-dropdown>
-                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costCodesImportToggle" [disabled]="true" aria-label="Import cost codes"></p-inputSwitch>
+                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costCodesImportToggle" [disabled]="true" aria-label="Import cost codes" role="switch"></p-inputSwitch>
                         </div>
                         <div class="tw-flex tw-pt-4" *ngIf="importSettingsForm.get('isDependentImportEnabled')?.value">
                             <div>
@@ -180,7 +180,7 @@
                                         {{ option.display_name }}                                    </div>
                                   </ng-template>
                             </p-dropdown>
-                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costTypesImportToggle" [disabled]="true" aria-label="Import cost types"></p-inputSwitch>
+                            <p-inputSwitch class="tw-pl-32-px input-toggle-section" formControlName="costTypesImportToggle" [disabled]="true" aria-label="Import cost types" role="switch"></p-inputSwitch>
                         </div>
                     </div>
                 </div>

--- a/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.ts
+++ b/src/app/integrations/intacct/intacct-shared/intacct-import-settings/intacct-import-settings.component.ts
@@ -20,6 +20,8 @@ import { SiImportSettingService } from 'src/app/core/services/si/si-configuratio
 import { IntacctConnectorService } from 'src/app/core/services/si/si-core/intacct-connector.service';
 import { SiMappingsService } from 'src/app/core/services/si/si-core/si-mappings.service';
 import { SiWorkspaceService } from 'src/app/core/services/si/si-core/si-workspace.service';
+import { SentenceCasePipe } from 'src/app/shared/pipes/sentence-case.pipe';
+import { SnakeCaseToSpaceCasePipe } from 'src/app/shared/pipes/snake-case-to-space-case.pipe';
 
 @Component({
   selector: 'app-intacct-import-settings',
@@ -62,6 +64,8 @@ export class IntacctImportSettingsComponent implements OnInit {
   toggleSwitchTrue: boolean = true;
 
   intacctCategoryDestination: IntacctCategoryDestination;
+
+  intacctCategoryDestinationLabel: string;
 
   showDialog: boolean;
 
@@ -642,6 +646,11 @@ export class IntacctImportSettingsComponent implements OnInit {
         } else {
           this.intacctCategoryDestination = IntacctCategoryDestination.GL_ACCOUNT;
         }
+
+        let label = new SnakeCaseToSpaceCasePipe().transform(this.intacctCategoryDestination);
+        label = new SentenceCasePipe().transform(label);
+        label = label.replace('Gl ', 'GL ');
+        this.intacctCategoryDestinationLabel = label;
 
         this.initializeForm(importSettings);
       }


### PR DESCRIPTION
## Clickup
https://app.clickup.com/t/86cz6aap1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
	- Improved accessibility of toggle switches in Intacct import settings by adding descriptive ARIA labels for screen readers.
- **Enhancements**
	- Updated category destination label display for improved clarity and readability in the import settings interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->