### PR TITLE
fix: i18n netsuite advanced settings translation issue

### DIFF
--- a/src/app/core/services/netsuite/netsuite-configuration/netsuite-advanced-settings.service.ts
+++ b/src/app/core/services/netsuite/netsuite-configuration/netsuite-advanced-settings.service.ts
@@ -52,7 +52,7 @@ export class NetsuiteAdvancedSettingsService extends AdvancedSettingsService {
   getPaymentSyncOptions(): SelectFormOption[] {
     return [
       {
-        label: this.translocoService.translate('services.netsuiteAdvancedSettings.exportNetsuitePayments'),
+        label: this.translocoService.translate('services.netsuiteAdvancedSettings.exportACHPayments'),
         value: NetsuitePaymentSyncDirection.FYLE_TO_NETSUITE
       },
       {

--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-advanced-settings/netsuite-advanced-settings.component.html
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-advanced-settings/netsuite-advanced-settings.component.html
@@ -16,7 +16,7 @@
         <div class="tw-p-24-px">
             <div class="tw-mb-16-px">
                 <app-configuration-step-sub-header
-                    [label]="'netsuite.configuration.advancedSettings.automation' | transloco"
+                    [label]="'netsuiteAdvancedSettings.automation' | transloco"
                     [subLabel]="'netsuite.configuration.advancedSettings.automationSubLabel' | transloco: {brandName: brandingConfig.brandName}">
                 </app-configuration-step-sub-header>
             </div>


### PR DESCRIPTION
### Description
i18n netsuite advanced settings translation issue

## Clickup
https://app.clickup.com/1864988/v/l/li/901607316229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated label text for the first payment sync option in advanced settings.
  * Modified the label in the advanced settings automation section for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->