### PR TITLE
fix(e2e): add aria-labels to mapping header counts

### DIFF
--- a/src/app/shared/components/helper/mapping/mapping-card-header/mapping-card-header.component.html
+++ b/src/app/shared/components/helper/mapping/mapping-card-header/mapping-card-header.component.html
@@ -1,6 +1,6 @@
 <div class="tw-flex tw-justify-between">
     <div class="tw-flex">
-        <div class="tw-rounded-10-px tw-bg-lv-stats-bg tw-border-1-px tw-border-border-tertiary tw-pt-16-px tw-pr-56-px tw-pb-10-px tw-pl-16-px tw-h-84-px" [ngClass]="brandingStyle.mapping.mappingHeaderBoxShadow">
+        <div class="tw-rounded-10-px tw-bg-lv-stats-bg tw-border-1-px tw-border-border-tertiary tw-pt-16-px tw-pr-56-px tw-pb-10-px tw-pl-16-px tw-h-84-px" [ngClass]="brandingStyle.mapping.mappingHeaderBoxShadow" [attr.aria-label]="('mappingCardHeader.total' | transloco) + ' ' + getPluralOfSourceField(sourceField)">
             <div class="tw-w-34-px tw-h-6-px tw-rounded-12-px tw-bg-bg-brand-muted">
             </div>
             <div class="tw-pt-8-px tw-text-lv-stats-label-text-color tw-text-12-px">
@@ -11,7 +11,7 @@
             </div>
         </div>
         <span class="tw-pl-16-px"></span>
-        <div class="tw-rounded-10-px tw-bg-white tw-border-1-px tw-border-border-tertiary tw-pt-16-px tw-pr-56-px tw-pb-10-px tw-pl-16-px tw-h-84-px" [ngClass]="brandingStyle.mapping.mappingHeaderBoxShadow">
+        <div class="tw-rounded-10-px tw-bg-white tw-border-1-px tw-border-border-tertiary tw-pt-16-px tw-pr-56-px tw-pb-10-px tw-pl-16-px tw-h-84-px" [ngClass]="brandingStyle.mapping.mappingHeaderBoxShadow" [attr.aria-label]="('mappingCardHeader.unmapped' | transloco) + ' ' + getPluralOfSourceField(sourceField)">
             <div class="tw-w-34-px tw-h-6-px tw-rounded-12-px tw-bg-bg-brand-muted">
             </div>
             <div class="tw-pt-8-px tw-text-lv-stats-label-text-color tw-text-12-px">


### PR DESCRIPTION

## Clickup
https://app.clickup.com/t/86cz6aap1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support by adding descriptive labels to header boxes in the mapping card header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->