### PR TITLE
feat: Add Cursor rules for i18n key patterns and fix .gitignore

### DIFF
--- a/.cursor/rules/atomics-i18n-key-pattern.mdc
+++ b/.cursor/rules/atomics-i18n-key-pattern.mdc
@@ -1,0 +1,115 @@
+---
+description: i18n keys for services, pipes, and directives
+globs:
+  - "**/*.service.ts"
+  - "**/*.pipe.ts"
+  - "**/*.directive.ts"
+alwaysApply: false
+---
+
+### Naming schemas
+services.<serviceName>.<messageKey>
+pipes.<pipeName>.<messageKey>
+directives.<directiveName>.<messageKey>
+
+### File stem conversion
+Convert kebab-case file names to camelCase and remove suffixes:
+- `report-expenses.service.ts` → `reportExpenses` (remove "Service" suffix)
+- `date-format.pipe.ts` → `dateFormat` (remove "Pipe" suffix)
+- `drop-zone.directive.ts` → `dropZone` (remove "Directive" suffix)
+
+**Suffix removal:** `Service`, `Pipe`, `Directive`
+
+### Key naming guidelines
+- Use meaningful, semantic, and context-aware key names
+- Prefer keys like `spendDate`, `invalidDate`, `uploadPrompt`
+- Avoid generic names like `message1`, `text1`, `error1`
+- The key should help developers understand the purpose just by reading it
+
+### Example
+```jsonc
+{
+  "services": {
+    "myExpenses": {
+      "spendDate": "Spend Date",
+      "validationError": "Invalid expense data"
+    }
+  },
+  "pipes": {
+    "dateFormat": {
+      "invalidDate": "Invalid date",
+      "formatError": "Date format error"
+    }
+  },
+  "directives": {
+    "dropZone": {
+      "uploadPrompt": "Drag files here to upload",
+      "fileTooLargeError": "File is too large"
+    }
+  }
+}
+```
+
+### Bad Examples (What NOT to do)
+```jsonc
+// ❌ BAD - Wrong file name conversion (includes suffix)
+{
+  "services": {
+    "reportExpensesService": {  // Should be "reportExpenses" (remove "Service")
+      "spendDate": "Spend Date"
+    }
+  }
+}
+
+// ❌ BAD - Generic key names
+{
+  "services": {
+    "myExpenses": {
+      "message1": "Spend Date",
+      "error1": "Invalid data"
+    }
+  }
+}
+
+// ❌ BAD - Wrong atomic grouping
+{
+  "myExpenses": {  // Should be under "services" group
+    "spendDate": "Spend Date"
+  }
+}
+```
+
+### TypeScript usage examples
+```typescript
+// In services
+this.translocoService.translate('services.myExpenses.validationError');
+
+// In pipes
+return this.translocoService.translate('pipes.dateFormat.invalidDate');
+
+// In directives
+this.element.nativeElement.title = this.translocoService.translate('directives.dropZone.fileTooLargeError');
+```
+
+### JSON placement rule
+**File Location** → **Translation File Location**
+
+- **If file is in:** `src/**`
+  **Then put key in:** `src/assets/i18n/{lang}.json`
+
+**Note:** Add the key to every supported language file (e.g., `en.json`, `es.json`, etc.).
+
+### What NOT to translate
+- Strings that are already translation keys (e.g., `'service.key' | transloco`)
+- Tracking/analytics strings (e.g., `this.trackingService.trackEvent('User action')`)
+- Strings with only special characters (e.g., `'-'`, `','`, `'.'`)
+- Comments and non-user-visible text
+- Variable bindings and expressions
+- Internal error messages not shown to users
+
+### Rules to remember
+- Use only the three roots: services, pipes, directives.
+- Convert file names from kebab-case to camelCase for the key name.
+- Remove Service, Pipe, Directive suffixes from file names.
+- Keep child keys alphabetically sorted to reduce merge conflicts.
+- Use semantic key names that describe the purpose.

--- a/.cursor/rules/component-i18n-key-naming.mdc
+++ b/.cursor/rules/component-i18n-key-naming.mdc
@@ -1,0 +1,112 @@
+---
+description: i18n keys for Angular components & templates
+globs:
+  - "**/*.component.ts"
+  - "**/*.component.html"
+alwaysApply: false
+---
+
+### Naming pattern
+- Top‑level object **must** be the component / feature folder name.
+- Keys inside that object are free‑form and **not** prefixed.
+- No nested objects beyond the first level.
+
+### File name conversion
+Convert kebab-case file names to camelCase and remove prefixes:
+- `sign-in.component.html` → `signIn`
+- `feature-user-profile.component.ts` → `userProfile` (remove "feature" prefix)
+- `ui-button.component.html` → `button` (remove "ui" prefix)
+- `component-header.component.ts` → `header` (remove "component" prefix)
+
+**Prefix removal order:** `feature`, `ui`, `component`
+
+### Key naming guidelines
+- Use meaningful, semantic, and context-aware key names
+- Prefer keys like `title`, `subtitle`, `accountDisabledError`, `submitButton`
+- Avoid generic names like `label1`, `text1`, `message1`
+- The key should help developers understand the purpose just by reading it
+
+### Example
+```jsonc
+{
+  "signIn": {
+    "title": "Sign in",
+    "subtitle": "Enter your credentials",
+    "accountDisabledError": "Account is disabled",
+    "submitButton": "Sign In",
+    "forgotPasswordButton": "Forgot Password?"
+  }
+}
+```
+
+### Bad Examples (What NOT to do)
+```jsonc
+// ❌ BAD - Nested objects (forbidden)
+{
+  "signIn": {
+    "error": {
+      "accountDisabled": "Account is disabled"
+    },
+    "button": {
+      "submit": "Sign In"
+    }
+  }
+}
+
+// ❌ BAD - Generic key names
+{
+  "signIn": {
+    "label1": "Sign in",
+    "text1": "Enter credentials",
+    "message1": "Account is disabled"
+  }
+}
+
+// ❌ BAD - Wrong file name conversion
+{
+  "signInComponent": {  // Should be "signIn" (remove "Component" suffix)
+    "title": "Sign in"
+  }
+}
+```
+
+### Angular binding examples
+```html
+<!-- Property binding for attributes -->
+<input [placeholder]="'signIn.subtitle' | transloco" />
+
+<!-- Interpolation for static text -->
+<h1>{{ 'signIn.title' | transloco }}</h1>
+
+<!-- Static attributes -->
+<button title="{{ 'signIn.submitButton' | transloco }}">
+  {{ 'signIn.submitButton' | transloco }}
+</button>
+```
+
+```typescript
+// In TypeScript
+this.translocoService.translate('signIn.accountDisabledError');
+```
+
+### JSON placement rule
+**File Location** → **Translation File Location**
+
+- **If file is in:** `src/**`
+  **Then put key in:** `src/assets/i18n/{lang}.json`
+
+**Note:** Add the key to every supported language file (e.g., `en.json`, `es.json`, etc.).
+
+### What NOT to translate
+- Strings that are already translation keys (e.g., `'component.key' | transloco`)
+- Tracking/analytics strings (e.g., `this.trackingService.trackEvent('User clicking')`)
+- Strings with only special characters (e.g., `'-'`, `','`, `'.'`)
+- Comments and non-user-visible text
+- Variable bindings and expressions
+
+### Rules to remember
+- One object per component/feature.
+- No deep nesting ("advancedFilters": { "amount": … } is forbidden).
+- Avoid prefixes like ui*, feature*; the object name is the context.
+- Use semantic key names that describe the purpose.
+- Prefer property binding for user-facing attributes.

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 
 # Compiled output
 .cursorrules
-.cursor/
+.cursor/*
+!.cursor/rules/
+!.cursor/rules/**
+
 /dist
 /tmp
 /out-tsc


### PR DESCRIPTION
### Description
Please add PR description here, add screenshots if needed

## Clickup
https://app.clickup.com/t/86czc6pn3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidelines for internationalization (i18n) key naming conventions for Angular components, templates, services, pipes, and directives.
  * Provided examples and best practices for organizing and referencing translation keys.
* **Chores**
  * Updated the ignore settings to include the `.cursor/rules` directory in version control while excluding other `.cursor` contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->