### PR TITLE
fix: primary buttons sage theme misses on qbd iff

### DIFF
--- a/src/app/integrations/qbd/qbd-main/qbd-dashboard/qbd-dashboard.component.html
+++ b/src/app/integrations/qbd/qbd-main/qbd-dashboard/qbd-dashboard.component.html
@@ -15,13 +15,7 @@
                 </div>
                 <div class="tw-flex tw-items-end tw-justify-end">
                     <div>
-                        <button type="button" class="export-btn tw-float-right tw-flex tw-justify-end tw-items-center tw-text-white tw-text-500 tw-px-24-px tw-py-12-px tw-bg-mandatory-field-color tw-rounded-4-px" (click)="triggerExports()" [disabled]="exportInProgress || disableQBDExportButton" >
-                            <p class="tw-flex tw-text-14-px tw-font-400 tw-pl-5px" *ngIf="!exportInProgress">{{ 'qbdDashboard.exportIifFileButton' | transloco }}
-                                <app-svg-icon *ngIf="brandingFeatureConfig.isIconsInsideButtonAllowed" [svgSource]="'arrow-tail-right-medium'" [width]="'18px'" [height]="'18px'" [styleClasses]="'tw-pl-10-px tw-pt-2-px !tw-text-12-px'"></app-svg-icon>
-                            </p>
-                            <p class="tw-text-14-px tw-font-400 tw-pl-5px" *ngIf="exportInProgress">{{ 'qbdDashboard.exportingButton' | transloco }}
-                            </p>
-                        </button><br>
+                        <app-primary-button (buttonClick)="triggerExports()" [styleClasses]="'tw-h-10 tw-px-24-px tw-py-8-px'" [svgSource]="'arrow-tail-right-medium'" [disabled]="exportInProgress || disableQBDExportButton" [buttonText]="!exportInProgress ? ('qbdDashboard.exportIifFileButton' | transloco) : ('qbdDashboard.exportingButton' | transloco)"></app-primary-button>
                         <p *ngIf="nextExportDate" class="tw-pt-8-px tw-float-right tw-text-12-px tw-font-500 tw-text-text-muted">{{ 'qbdDashboard.nextExportSchedule' | transloco }} {{ nextExportDate | date : 'd MMM, yyyy'}}</p>
                     </div>
                 </div>

--- a/src/app/integrations/qbd/qbd-onboarding/qbd-onboarding-done/qbd-onboarding-done.component.html
+++ b/src/app/integrations/qbd/qbd-onboarding/qbd-onboarding-done/qbd-onboarding-done.component.html
@@ -10,7 +10,7 @@
       <h2 class="tw-text-normal-text-color !tw-font-bold !tw-text-18-px">{{ 'qbdOnboardingDone.congratulationsMessage' | transloco }}</h2>
     </div>
     <div class="tw-flex tw-justify-center tw-py-24-px">
-        <button type="button" class="tw-text-500 tw-text-white tw-px-24-px tw-py-12-px tw-bg-mandatory-field-color tw-rounded-4-px" (click)="navigateToDashboard()">{{ 'qbdOnboardingDone.launchButtonText' | transloco }}</button>
+        <app-primary-button [styleClasses]="'tw-h-10 tw-px-24-px tw-py-8-px'" [buttonText]="'qbdOnboardingDone.launchButtonText' | transloco " (buttonClick)="navigateToDashboard()"></app-primary-button>
     </div>
     <div class="tw-py-24-px">
       <h5 class="tw-text-text-muted tw-text-center tw-text-14-px" [innerHTML]="'qbdOnboardingDone.reconfigureMessage' | transloco">


### PR DESCRIPTION
### Description
primary buttons sage theme misses on qbd iff

## Clickup
https://app.clickup.com/1864988/v/l/6-901610119496-1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced native and custom-styled button elements with a unified primary button component for export actions and navigation.
  * Maintained existing button functionality, appearance, and disabled states while streamlining button logic and event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->