### PR TITLE
fix: handle Intacct connection expiration in token guard

### DIFF
--- a/src/app/core/guard/intacct-token.guard.ts
+++ b/src/app/core/guard/intacct-token.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from "@angular/router";
-import { Observable, map, catchError, throwError } from "rxjs";
+import { Observable, map, catchError, throwError, of } from "rxjs";
 import { globalCacheBusterNotifier } from "ts-cacheable";
 import { WorkspaceService } from "../services/common/workspace.service";
 import { AppUrl } from "../models/enum/enum.model";
@@ -36,10 +36,13 @@ export class IntacctTokenGuard  {
           if (error.status === 400) {
             globalCacheBusterNotifier.next();
 
+            if (error.error.message === "Intacct connection expired"){
+              return this.router.navigateByUrl('integrations/intacct/token_expired/dashboard');
+            }
             // Treat fallback as token expired
             return this.router.navigateByUrl('integrations/intacct/token_expired/dashboard');
           }
-          return throwError(error);
+          return of(true);
         })
       );
   }

--- a/src/app/core/guard/netsuite-token.guard.ts
+++ b/src/app/core/guard/netsuite-token.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from "@angular/router";
-import { Observable, map, catchError, throwError } from "rxjs";
+import { Observable, map, catchError, throwError, of } from "rxjs";
 import { globalCacheBusterNotifier } from "ts-cacheable";
 import { WorkspaceService } from "../services/common/workspace.service";
 import { AppUrl } from "../models/enum/enum.model";
@@ -35,10 +35,14 @@ export class NetsuiteTokenGuard  {
         catchError(error => {
           if (error.status === 400) {
             globalCacheBusterNotifier.next();
+
+            if (error.error.message === "Netsuite connection expired"){
+              return this.router.navigateByUrl('integrations/netsuite/token_expired/dashboard');
+            }
             // Treat fallback as token expired
             return this.router.navigateByUrl('integrations/netsuite/token_expired/dashboard');
           }
-          return throwError(error);
+          return of(true);
         })
       );
   }

--- a/src/app/core/guard/qbo-token.guard.ts
+++ b/src/app/core/guard/qbo-token.guard.ts
@@ -1,6 +1,6 @@
 import {  Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
-import { Observable, catchError, map, throwError } from 'rxjs';
+import { Observable, catchError, map, throwError, of } from 'rxjs';
 import { WorkspaceService } from '../services/common/workspace.service';
 import { QboConnectorService } from '../services/qbo/qbo-configuration/qbo-connector.service';
 import { globalCacheBusterNotifier } from 'ts-cacheable';
@@ -43,6 +43,10 @@ export class QboTokenGuard  {
               return this.router.navigateByUrl('integrations/qbo/onboarding/connector');
             }
 
+            if (error.error.message === "Quickbooks Online connection expired") {
+              return this.router.navigateByUrl('integrations/qbo/token_expired/dashboard');
+            }
+
             if (error.error.message === "Quickbooks Online disconnected") {
               return this.router.navigateByUrl('integrations/qbo/disconnect/dashboard');
             }
@@ -51,7 +55,7 @@ export class QboTokenGuard  {
             return this.router.navigateByUrl('integrations/qbo/token_expired/dashboard');
           }
 
-          return throwError(error);
+          return of(true);
         })
       );
 

--- a/src/app/core/guard/sage300-token.guard.ts
+++ b/src/app/core/guard/sage300-token.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from "@angular/router";
-import { Observable, map, catchError, throwError } from "rxjs";
+import { Observable, map, catchError, throwError, of } from "rxjs";
 import { globalCacheBusterNotifier } from "ts-cacheable";
 import { WorkspaceService } from "../services/common/workspace.service";
 import { AppUrl } from "../models/enum/enum.model";
@@ -36,10 +36,13 @@ export class Sage300TokenGuard  {
           if (error.status === 400) {
             globalCacheBusterNotifier.next();
 
+            if (error.error.message === "Sage300 connection expired"){
+              return this.router.navigateByUrl('integrations/sage300/token_expired/dashboard');
+            }
             // Treat fallback as token expired
             return this.router.navigateByUrl('integrations/sage300/token_expired/dashboard');
           }
-          return throwError(error);
+          return of(true);
         })
       );
   }

--- a/src/app/core/guard/xero-token.guard.ts
+++ b/src/app/core/guard/xero-token.guard.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from "@angular/router";
 import { XeroConnectorService } from "../services/xero/xero-configuration/xero-connector.service";
-import { Observable, map, catchError, throwError } from "rxjs";
+import { Observable, map, catchError, throwError, of } from "rxjs";
 import { globalCacheBusterNotifier } from "ts-cacheable";
 import { WorkspaceService } from "../services/common/workspace.service";
 import { AppUrl, ToastSeverity, XeroOnboardingState } from "../models/enum/enum.model";
@@ -44,6 +44,10 @@ export class XeroTokenGuard  {
               return this.router.navigateByUrl('integrations/xero/onboarding/connector');
             }
 
+            if (error.error.message === "Xero connection expired"){
+              return this.router.navigateByUrl('integrations/xero/token_expired/dashboard');
+            }
+
             if (error.error.message === "Xero disconnected"){
               return this.router.navigateByUrl('integrations/xero/disconnect/dashboard');
             }
@@ -52,7 +56,7 @@ export class XeroTokenGuard  {
             return this.router.navigateByUrl('integrations/xero/token_expired/dashboard');
           }
 
-          return throwError(error);
+          return of(true);
         })
       );
   }


### PR DESCRIPTION
### Description
fix: handle Intacct connection expiration in token guard

## Clickup
https://app.clickup.com/ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added automatic redirect to each integration's token-expired dashboard when its connection has expired (Intacct, NetSuite, QuickBooks, Sage300, Xero).

- Bug Fixes
  - More consistent handling of integration-expired messages to ensure users are routed to the correct reauthentication page.

- Improvements
  - Non-400/non-critical errors now allow app activation to proceed, reducing unnecessary interruptions for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->