### PR TITLE
fix: revert the height of all inputs back to 40px

### DIFF
--- a/src/assets/themes/fyle/fdl.scss
+++ b/src/assets/themes/fyle/fdl.scss
@@ -312,7 +312,7 @@
 
     --select-default-placeholder-text: var(--text-placeholder);
 
-    --dropdown-option-height: 25px;
+    --dropdown-option-height: 32px;
 
     --dd-menu-item-default-text-color: var(--text-secondary);
 
@@ -451,7 +451,7 @@
     --toggle-border-width: 1px;
 
     // Inputs
-    --input-height: 32px;
+    --input-height: 40px;
 
     // Input - Disabled
     --input-disabled-bg: #{$utility-major-25};

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -67,25 +67,18 @@
 
         // Dropdowns
         .p-dropdown {
-            @apply tw-h-32-px tw-py-5-px #{!important};
+            @apply tw-h-input-height #{!important};
         }
 
         .p-dropdown-trigger, .p-dropdown-trigger > *, .pi-chevron-down.fyle {
             content: url('./assets/icons/caret-large-down.svg') !important;
         }
 
-        .p-dropdown .p-dropdown-trigger {
-            @apply tw-w-20-px tw-h-20-px #{!important};
-        }
 
         // Dropdown panel
-        .p-dropdown-panel .p-dropdown-items {
-            @apply tw-mt-1-px tw-px-0 tw-py-12-px tw-border tw-border-box-color tw-rounded-b-8-px tw-border-none #{!important};
-        }
-
         .p-dropdown-panel .p-dropdown-items .p-dropdown-item.p-highlight, .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-highlight .p-focus
         ,.p-dropdown-panel .p-dropdown-items .p-dropdown-item.p-highlight:hover {
-            @apply tw-text-white tw-bg-select-menu-item-active-bg tw-rounded-none tw-min-h-dropdown-option-height tw-flex tw-items-center tw-py-2-px tw-pl-12-px tw-text-14-px #{!important};
+            @apply tw-text-white tw-bg-select-menu-item-active-bg tw-rounded-none tw-min-h-dropdown-option-height tw-flex tw-items-center tw-text-14-px #{!important};
 
             p {
                 @apply tw-text-utility-major-50;
@@ -93,7 +86,7 @@
         }
 
         .p-dropdown-panel .p-dropdown-items .p-dropdown-item:not(.p-highlight).p-focus {
-            @apply tw-text-slightly-normal-text-color tw-bg-white tw-rounded-none tw-min-h-dropdown-option-height tw-flex tw-items-center tw-py-2-px tw-px-12-px tw-text-14-px #{!important};
+            @apply tw-text-slightly-normal-text-color tw-bg-white tw-rounded-none tw-min-h-dropdown-option-height tw-flex tw-items-center tw-text-14-px #{!important};
         }
 
         .p-dropdown-panel .p-dropdown-items .p-dropdown-item:hover, .p-dropdown-panel .p-dropdown-items .p-dropdown-item:not(.p-highlight).p-focus:hover{
@@ -101,7 +94,7 @@
         }
 
         .p-dropdown-panel .p-dropdown-items .p-dropdown-item {
-            @apply tw-min-h-dropdown-option-height tw-py-2-px tw-px-12-px #{!important};
+            @apply tw-min-h-dropdown-option-height #{!important};
         }
 
         .p-dropdown-panel .p-dropdown-items .p-dropdown-item p {
@@ -124,14 +117,14 @@
 
         // Text inputs
         input[type="text"]:not(.p-chips-input-token > input), input[type="password"] {
-            @apply tw-h-32-px tw-py-5-px tw-border tw-border-utility-major-300 tw-text-14-px #{!important};
+            @apply tw-h-input-height tw-border tw-border-utility-major-300 tw-text-14-px #{!important};
         }
 
         input[type="text"]:not(.p-dropdown-filter-container > input):not(.custom-search-field > input):not(.p-chips-input-token > input):not(.p-multiselect-chip input) {
             @apply tw-px-14-px #{!important};
         }
 
-        input[type="text"]:disabled, input[type="password"]:disabled {
+        input[type="text"]:not(.p-chips-input-token > input):disabled, input[type="password"]:disabled {
             @apply tw-bg-input-disabled-bg tw-border-input-disabled-border #{!important};
         }
 


### PR DESCRIPTION
### Description
We initially reduced the heights of all inputs, dropdowns, multiselects, and their options from `40px` to `32px` ([figma](https://www.figma.com/design/0CH5dJoMBjHTaZ42MqnKDZ/Sage-Product-Brand-Guidelines?node-id=7-20646&m=dev)). However, this affected multiple components unintentionally (pills dropdown in mapping pages, skip export section, etc.). We are now sticking to the original height of `40px`.
<img width="359" height="93" alt="Screenshot 2025-08-14 at 2 10 00 PM" src="https://github.com/user-attachments/assets/5dd8bd25-9d52-4835-a451-7d1c82dd5117" />
<img width="371" height="302" alt="Screenshot 2025-08-14 at 2 10 24 PM" src="https://github.com/user-attachments/assets/d18d6417-069d-4ca6-ad0c-a1b677319ac6" />
<img width="254" height="216" alt="Screenshot 2025-08-14 at 2 11 19 PM" src="https://github.com/user-attachments/assets/df8560e9-9539-41b3-bd85-d0e59eb26a8a" />
<img width="244" height="94" alt="Screenshot 2025-08-14 at 2 11 25 PM" src="https://github.com/user-attachments/assets/c44ab257-5be3-4bc6-b0ed-e1f1c676f633" />
<img width="251" height="83" alt="Screenshot 2025-08-14 at 2 11 43 PM" src="https://github.com/user-attachments/assets/d9ae0559-b8ff-4de8-aab6-a4c12b369e36" />
<img width="359" height="183" alt="Screenshot 2025-08-14 at 2 16 13 PM" src="https://github.com/user-attachments/assets/0a7f0c2c-4183-4d17-839b-d5b2c995b99c" />
<img width="370" height="364" alt="Screenshot 2025-08-14 at 2 16 52 PM" src="https://github.com/user-attachments/assets/86219954-1cfc-4f46-a18a-23073a396bfc" />
<img width="985" height="207" alt="Screenshot 2025-08-14 at 2 18 13 PM" src="https://github.com/user-attachments/assets/5b625e24-0ac3-4ea8-b8af-5416da758896" />
<img width="468" height="351" alt="Screenshot 2025-08-14 at 2 20 47 PM" src="https://github.com/user-attachments/assets/f89b6233-6d15-43cf-8f23-da91df4238b6" />
<img width="493" height="448" alt="Screenshot 2025-08-14 at 2 21 49 PM" src="https://github.com/user-attachments/assets/6636c0fd-893a-4b51-8b33-4fd23bd01ee4" />
<img width="368" height="196" alt="Screenshot 2025-08-14 at 2 25 26 PM" src="https://github.com/user-attachments/assets/04b632ca-a916-45e5-8374-158184f9ba36" />
<img width="367" height="314" alt="Screenshot 2025-08-14 at 2 25 41 PM" src="https://github.com/user-attachments/assets/207a01f2-c039-419b-a504-5251dd52c0ff" />


## Clickup
https://app.clickup.com/t/86czz5mjf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Increased input height for better touch targets.
  - Increased dropdown option height for improved readability.
  - Unified input and dropdown heights using a shared sizing token.
  - Reduced excess padding in dropdown items for a cleaner, denser list.
  - Tweaked dropdown item text styling in the Fyle theme for clearer contrast.

- Bug Fixes
  - Refined disabled styling to apply correctly to standalone text/password inputs, excluding inputs embedded within chips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->