### PR TITLE
ui: update dropdown colors to match carbon

### DIFF
--- a/src/assets/themes/fyle/fdl.scss
+++ b/src/assets/themes/fyle/fdl.scss
@@ -322,7 +322,7 @@
 
     --dropdown-option-height: 32px;
 
-    --dd-menu-item-default-text-color: var(--text-secondary);
+    --dd-menu-item-default-text-color: var(--text-primary);
 
     --dd-menu-item-hover-bg: var(--bg-tertiary);
 
@@ -470,10 +470,10 @@
 
     // Select
     --select-default-border: #{$utility-major-300};
-    --select-menu-item-active-bg: #{$action-major-500};
+    --select-menu-item-active-bg: #{$utility-major-200};
 
     // Colors Utility
-    --colors-utility-yin-090: #{$colors-utility-yin-090};
+    --yin-090: #{$yin-090};
 
     // Action/Major - Primary theme colour for major actions (Jade)
     --action-major-25: #{$action-major-25};

--- a/src/assets/themes/fyle/fdl.scss
+++ b/src/assets/themes/fyle/fdl.scss
@@ -472,8 +472,13 @@
     --select-default-border: #{$utility-major-300};
     --select-menu-item-active-bg: #{$utility-major-200};
 
-    // Colors Utility
+    // Yin - Dark font colors
+    --yin-100: #{$yin-100};
     --yin-090: #{$yin-090};
+    --yin-075: #{$yin-075};
+    --yin-065: #{$yin-065};
+    --yin-055: #{$yin-055};
+    --yin-030: #{$yin-030};
 
     // Action/Major - Primary theme colour for major actions (Jade)
     --action-major-25: #{$action-major-25};

--- a/src/assets/themes/fyle/primitives_variables.scss
+++ b/src/assets/themes/fyle/primitives_variables.scss
@@ -108,8 +108,6 @@ $action-major-500: #007e45ff;
 $action-major-600: #006738ff;
 $action-major-700: #004d2aff;
 
-$colors-utility-yin-090: rgba(0, 0, 0, 0.90);
-
 // utility/major - This base colour is used to create our grayscale tints/shades
 $utility-major-10: #fafbfbff;
 $utility-major-25: #f2f5f6ff;
@@ -124,6 +122,15 @@ $utility-major-400: #335b70ff;
 $utility-major-450: #19475eff;
 $utility-major-500: #00324cff;
 $utility-major-800: #00141eff;
+
+// Font colors
+// Black - yin
+$yin-100: #000000;
+$yin-090: #1A1A1A;
+$yin-075: #404040;
+$yin-065: #595959;
+$yin-055: #737373;
+$yin-030: #B3B3B3;
 
 // Semantics colors - UI semantic colors denote standard states. Each color has the same meaning in all contexts.
 $semantic-focus-500: #ffbc19;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -93,10 +93,10 @@ app-intacct-onboarding > *:not(router-outlet) > *:not(app-onboarding-steppers) {
     // Dropdown panel
     .p-dropdown-panel .p-dropdown-items .p-dropdown-item.p-highlight, .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-highlight .p-focus
     ,.p-dropdown-panel .p-dropdown-items .p-dropdown-item.p-highlight:hover {
-        @apply tw-text-white tw-bg-select-menu-item-active-bg tw-rounded-none tw-min-h-dropdown-option-height tw-flex tw-items-center tw-text-14-px #{!important};
+        @apply tw-text-dd-menu-item-default-text-color tw-bg-select-menu-item-active-bg tw-rounded-none tw-min-h-dropdown-option-height tw-flex tw-items-center tw-text-14-px #{!important};
 
         p {
-            @apply tw-text-utility-major-50;
+            @apply tw-text-yin-065;
         }
     }
 
@@ -105,7 +105,7 @@ app-intacct-onboarding > *:not(router-outlet) > *:not(app-onboarding-steppers) {
     }
 
     .p-dropdown-panel .p-dropdown-items .p-dropdown-item:hover, .p-dropdown-panel .p-dropdown-items .p-dropdown-item:not(.p-highlight).p-focus:hover{
-        @apply tw-bg-utility-major-25 tw-text-slightly-normal-text-color tw-rounded-none #{!important};
+        @apply tw-bg-utility-major-100 tw-text-slightly-normal-text-color tw-rounded-none #{!important};
     }
 
     .p-dropdown-panel .p-dropdown-items .p-dropdown-item {
@@ -118,6 +118,10 @@ app-intacct-onboarding > *:not(router-outlet) > *:not(app-onboarding-steppers) {
 
     .p-dropdown-panel {
         @apply tw-translate-y-[7px] tw-shadow-base-shadow;
+    }
+
+    .p-dropdown-header {
+        @apply tw-bg-white #{!important}
     }
 
     // Dropdown - Error state
@@ -537,7 +541,7 @@ p {
     }
 
     .p-radiobutton .p-radiobutton-box .p-radiobutton-icon {
-        @apply tw-w-8-px tw-h-8-px tw-bg-colors-utility-yin-090 #{!important};
+        @apply tw-w-8-px tw-h-8-px tw-bg-yin-090 #{!important};
     }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,8 +36,13 @@ const customColors = {
   'bg-qbo-btn': 'var(--bg-qbo-btn)',
   'bg-xero-btn': 'var(--bg-xero-btn)',
 
-  // Colors Utility
-  'colors-utility-yin-090': 'var(--colors-utility-yin-090)',
+  // Black - yin (Font colors)
+  'yin-100': 'var(--yin-100)',
+  'yin-090': 'var(--yin-090)',
+  'yin-075': 'var(--yin-075)',
+  'yin-065': 'var(--yin-065)',
+  'yin-055': 'var(--yin-055)',
+  'yin-030': 'var(--yin-030)',
 
   // Action/Major colors (Jade theme for major actions)
   'action-major-25': 'var(--action-major-25)',


### PR DESCRIPTION
## Before
<img width="336" height="342" alt="Before" src="https://github.com/user-attachments/assets/8869b6d4-6e29-44ef-9ca0-19750ba56c2a" />

## After
<img width="366" height="366" alt="After" src="https://github.com/user-attachments/assets/990fb143-c501-4f16-b86d-70b3b3a33250" />

## Clickup
https://app.clickup.com/t/86d01q8eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved dropdown readability: clearer default item text color, updated active/hover backgrounds, and a distinct header background for better contrast.
  * Enhanced radio button appearance in the Fyle theme for improved visibility.
  * Introduced a refined "Yin" typography color palette (multiple new shades) for more consistent, accessible text across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->