### PR TITLE
feat: rebrand multiselect checkboxes

### DIFF
--- a/src/assets/themes/fyle/fdl.scss
+++ b/src/assets/themes/fyle/fdl.scss
@@ -329,7 +329,7 @@
 
     --dd-menu-item-hover-bg: var(--bg-tertiary);
 
-    --checkbox-icon-selected-color: var(--bg-brand-primary);
+    --checkbox-icon-selected-color: white;
 
     --checkbox-icon-color: var(--icon-disable);
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -162,8 +162,27 @@ app-intacct-onboarding > *:not(router-outlet) > *:not(app-onboarding-steppers) {
         @apply tw-rounded-full #{!important};
     }
 
+    // Multiselect checkboxes
+    .p-checkbox-box.p-highlight {
+        @apply tw-bg-white;
+    }
+
+    .p-checkbox-box.p-highlight .p-element.p-icon-wrapper {
+        @apply tw-relative tw-top-[-1.5px];
+    }
+
+    // Custom multiselect checkbox icon
+    .p-checkbox-box.p-highlight .p-element.p-icon-wrapper::before {
+        content: url('./assets/icons/carbon-tick.svg');
+    }
+
+    // Hide the default checkbox icon in multiselect
+    .p-checkbox-box.p-highlight .p-icon-wrapper svg {
+        @apply tw-hidden;
+    }
+
     // All other checkboxes
-    input[type="checkbox"] {
+    input[type="checkbox"], .p-checkbox .p-checkbox-box {
         @apply tw-appearance-none tw-w-16-px tw-h-16-px tw-inline-flex tw-content-center tw-justify-center tw-p-[1px] tw-border-1-px tw-border-utility-major-300 tw-rounded-[2px] tw-relative #{!important};
     }
 
@@ -259,6 +278,12 @@ app-intacct-onboarding > *:not(router-outlet) > *:not(app-onboarding-steppers) {
 
     .p-dialog:not(:has(.p-dialog-header)):not(:has(.p-dialog-footer)) .p-dialog-content {
         @apply tw-rounded-border-radius-2xs #{!important};
+    }
+
+    // Checkboxes - in multiselects
+
+    .p-checkbox .p-checkbox-box.p-highlight {
+        @apply tw-bg-checkbox-icon-selected-color tw-border-none #{!important};
     }
 }
 
@@ -715,10 +740,6 @@ p {
 
 .p-multiselect-panel .p-multiselect-items .p-multiselect-item:hover {
     @apply tw-shadow-none tw-bg-dd-menu-item-hover-bg tw-rounded-none #{!important};
-}
-
-.p-checkbox .p-checkbox-box.p-highlight {
-    @apply tw-bg-checkbox-icon-selected-color tw-border-none #{!important};
 }
 
 .pi-check:before {


### PR DESCRIPTION
## Before
<img width="363" height="300" alt="Screenshot 2025-08-25 at 1 33 22 PM" src="https://github.com/user-attachments/assets/372479ee-86ac-4e76-8ed8-f7d721414896" />

## After
<img width="338" height="274" alt="Screenshot 2025-08-25 at 3 01 04 PM" src="https://github.com/user-attachments/assets/f3f291de-dbc8-4507-9a0f-1954d350ad2d" />


## Clickup
https://app.clickup.com/t/86d01q8g7