### PR TITLE
fix: landing header copy across all integrations

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1056,7 +1056,7 @@
     "appName": "Dynamics 365 Business Central",
     "appDescription": "Import data from Dynamics 365 Business Central to {{brandName}} and export expenses from {{brandName}} to Dynamics 365 Business Central. ",
     "connectButton": "Connect",
-    "headlineText": "Guide to setup your integrations",
+    "headlineText": "Guide to setup your integration",
     "headerText": "A quick guide to help you set up the integration quick and easy.",
     "incorrectAccountDialogHeader": "Incorrect account selected",
     "incorrectAccountDialogContext": "You had previously set up the integration with a different Dynamics 365 Business Central account. Please choose the same to restore the settings",
@@ -1096,7 +1096,7 @@
     "appName": "Sage 300 CRE",
     "appDescription": "Import data from Sage 300 CRE to {{brandName}} and export expenses from {{brandName}} to Sage 300 CRE. ",
     "buttonText": "Connect",
-    "headlineText": "Guide to setup your integrations",
+    "headlineText": "Guide to setup your integration",
     "headerText": "A set up through to help you set up the integration quick and easy."
   },
   "sage300ConnectionForm": {

--- a/src/assets/i18n/fyle/en.json
+++ b/src/assets/i18n/fyle/en.json
@@ -2,7 +2,7 @@
   "qbd_direct": {
     "landing": {
       "contentText": "Import data from QuickBooks Desktop to {{brandName}} and export expenses from {{brandName}} to QuickBooks Desktop",
-      "guideHeaderText": "Guide to setup your integrations"
+      "guideHeaderText": "Guide to setup your integration"
     },
     "configuration": {
       "preRequisite": {
@@ -101,7 +101,7 @@
   "netsuite": {
     "landing": {
       "contentText": "Import data from NetSuite to {{brandName}} and export expenses from {{brandName}} to NetSuite. ",
-      "guideHeaderText": "Guide to setup your integrations"
+      "guideHeaderText": "Guide to setup your integration"
     },
     "configuration": {
       "connector": {
@@ -188,7 +188,7 @@
   "xero": {
     "landing": {
       "contentText": "Import data from Xero to {{brandName}} and export expenses from {{brandName}} to Xero. ",
-      "guideHeaderText": "Guide to setup your integrations"
+      "guideHeaderText": "Guide to setup your integration"
     },
     "configuration": {
       "connector": {
@@ -259,7 +259,7 @@
   "intacct": {
     "landing": {
       "contentText": "Import data from Sage Intacct to {{brandName}} and export expenses from {{brandName}} to Sage Intacct. ",
-      "guideHeaderText": "Guide to setup your integrations"
+      "guideHeaderText": "Guide to setup your integration"
     },
     "common": {
       "readMoreText": "Read more",
@@ -469,7 +469,7 @@
   },
   "landing": {
     "contentText": "Import data from QuickBooks Online to {{brandName}} and export expenses from {{brandName}} to QuickBooks Online. ",
-    "guideHeaderText": "Guide to setup your integrations"
+    "guideHeaderText": "Guide to setup your integration"
   },
   "common": {
     "readMoreText": "Read more",


### PR DESCRIPTION
### Description
"integrations" -> "integration"
<img width="1470" height="257" alt="image" src="https://github.com/user-attachments/assets/354edbba-8e0b-4ab8-9d17-eb61b7c651a3" />

## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated onboarding headers from “integrations” to “integration” for Business Central and Sage 300 CRE.
  * Harmonized guide header text across Fyle connectors (QuickBooks Desktop Direct, NetSuite, Xero, Sage Intacct, and the generic landing) to singular phrasing.
  * Improves clarity and consistency across onboarding screens.
  * No behavior changes; UI text only.
  * Affects English locale only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->