### PR TITLE
fix: quickbooks token expired page header text

### DIFF
--- a/src/app/shared/components/dashboard/dashboard-token-expired/dashboard-token-expired.component.html
+++ b/src/app/shared/components/dashboard/dashboard-token-expired/dashboard-token-expired.component.html
@@ -8,7 +8,7 @@
   @if (!isConnectionInProgress) {
   <div class="tw-flex tw-flex-col tw-items-center" [ngClass]="isTokenBasedAuthApp ? 'tw-gap-[32px]' : 'tw-gap-[4px]'">
 
-    <p class="tw-text-18-px tw-text-text-primary"> {{isIntegrationDisconnected ? 'dashboardTokenExpired.integrationDisconnected' : 'dashboardTokenExpired.connectionExpired' | transloco}} </p>
+    <p class="tw-text-18-px tw-text-text-primary"> {{ (isIntegrationDisconnected ? 'dashboardTokenExpired.integrationDisconnected' : 'dashboardTokenExpired.connectionExpired') | transloco }} </p>
     @if (!isIntegrationDisconnected) {
     @if (!isTokenBasedAuthApp) {
     <p class="tw-text-center tw-text-14-px tw-text-text-tertiary tw-w-[650px] tw-break-words tw-whitespace-normal">


### PR DESCRIPTION
### Description
quickbooks token expired page header text fix
<img width="808" height="610" alt="image" src="https://github.com/user-attachments/assets/c58770b7-42d9-4135-9751-c851218a5c20" />

## Clickup
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured both token-expiration messages are correctly translated, fixing cases where one message appeared untranslated.
  * Improved consistency of localized text on the dashboard’s token-expired notice.
  * No visual layout or interaction changes; only corrected text rendering for all locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->