### PR TITLE
fix: netsuite export settings, for CCC on BILL save button disabled

### DIFF
--- a/src/app/integrations/netsuite/netsuite-shared/netsuite-export-settings/netsuite-export-settings.component.ts
+++ b/src/app/integrations/netsuite/netsuite-shared/netsuite-export-settings/netsuite-export-settings.component.ts
@@ -172,6 +172,10 @@ export class NetsuiteExportSettingsComponent implements OnInit {
         this.exportSettingForm.controls.employeeFieldMapping.enable();
         this.exportSettingForm.controls.nameInJournalEntry.patchValue(NameInJournalEntry.EMPLOYEE);
       }
+
+      if (isCCCExportTypeSelected === NetSuiteCorporateCreditCardExpensesObject.BILL) {
+          this.exportSettingForm.controls.splitExpenseGrouping.disable();
+      }
     });
     this.exportSettingForm.controls.nameInJournalEntry.valueChanges.subscribe((isNameInJournalEntrySelected) => {
         if (isNameInJournalEntrySelected === NameInJournalEntry.MERCHANT ) {


### PR DESCRIPTION
### Description
netsuite export settings, for CCC on BILL save button disabled

## Clickup
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In NetSuite export settings, selecting the CCC export type “BILL” now automatically disables the Split Expense Grouping option, preventing incompatible configurations and streamlining setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->