### PR TITLE
fix: advanced settings multiselect field order by original group & card number last 4 digit content change

### DIFF
--- a/src/app/shared/components/configuration/configuration-multi-select/configuration-multi-select.component.ts
+++ b/src/app/shared/components/configuration/configuration-multi-select/configuration-multi-select.component.ts
@@ -52,6 +52,18 @@ export class ConfigurationMultiSelectComponent implements OnInit {
   ) { }
 
   onMultiSelectChange() {
+    const selectedValues = this.form.get(this.formControllerName)?.value;
+
+    if (selectedValues && selectedValues.length > 0) {
+      const optionsCopy = [...this.options];
+
+      const sortedValues = [...selectedValues].sort((a, b) => {
+        return optionsCopy.indexOf(a) - optionsCopy.indexOf(b);
+      });
+
+      this.form.get(this.formControllerName)?.setValue(sortedValues, { emitEvent: false });
+    }
+
     this.changeInMultiSelect.emit();
   }
 

--- a/src/app/shared/components/configuration/configuration-multi-select/configuration-multi-select.component.ts
+++ b/src/app/shared/components/configuration/configuration-multi-select/configuration-multi-select.component.ts
@@ -68,7 +68,13 @@ export class ConfigurationMultiSelectComponent implements OnInit {
   }
 
   getMemo(memo: string): string {
-    return memo === 'expense_key' ? this.translocoService.translate('configurationMultiSelect.expenseReportId') : new SnakeCaseToSpaceCasePipe().transform(new SentenceCasePipe(this.translocoService).transform(memo));
+    if (memo === 'expense_key') {
+      return this.translocoService.translate('configurationMultiSelect.expenseReportId');
+    } else if (memo === 'card_number') {
+      return this.translocoService.translate('configurationMultiSelect.cardNumber');
+    }
+      return new SnakeCaseToSpaceCasePipe().transform(new SentenceCasePipe(this.translocoService).transform(memo));
+
   }
 
   // Helper to join selected item labels into a single string for template rendering

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -14,7 +14,8 @@
     "toPreview": "to preview."
   },
   "configurationMultiSelect": {
-    "expenseReportId": "Expense/Report ID"
+    "expenseReportId": "Expense/Report ID",
+    "cardNumber": "Card number (last 4 digit)"
   },
   "configurationConfirmationDialog": {
     "areYouSureToContinue": "Are you sure you want to continue?",


### PR DESCRIPTION
### Description
advanced settings multiselect field order by original group & card number last 4 digit content change

## Clickup
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Multi-select now preserves the original option order for selected items.
  - Updates to selections avoid emitting redundant form change events.
  - More predictable add/remove behavior in the multi-select, improving form stability.

- **Localization**
  - Added translation key "Card number (last 4 digit)" for the multi-select display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->