### PR TITLE
fix: qbo import settings transloco content

### DIFF
--- a/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.html
+++ b/src/app/integrations/qbo/qbo-shared/qbo-import-settings/qbo-import-settings.component.html
@@ -74,8 +74,8 @@
                 <div class="tw-rounded-lg tw-border-border-tertiary tw-border tw-mt-24-px" *ngIf="isTaxGroupSyncAllowed && brandingFeatureConfig.featureFlags.importSettings.tax">
                     <app-configuration-toggle-field
                       [form]="importSettingForm"
-                      [label]="'configuration.exportSetting.taxCodeLabel' | transloco"
-                      [subLabel]="('configuration.exportSetting.taxCodeSubLabel' | transloco) + brandingConfig.brandName + ('qboImportSettings.selectableFieldOnExpense' | transloco)"
+                      [label]="'configuration.importSetting.taxCodeLabel' | transloco"
+                      [subLabel]="('configuration.importSetting.taxCodeSubLabel' | transloco) + brandingConfig.brandName + ('qboImportSettings.selectableFieldOnExpense' | transloco)"
                       [formControllerName]="'taxCode'"
                       [iconPath]="'arrow-tail-down'"
                       [hasDependentFields]="true">
@@ -85,7 +85,7 @@
                         [form]="importSettingForm"
                         [isFieldMandatory]="true"
                         [mandatoryErrorListName]="'qboImportSettings.mandatoryTaxCodeError' | transloco"
-                        [label]="'configuration.exportSetting.defaultTaxCodeLabel' | transloco"
+                        [label]="'configuration.importSetting.defaultTaxCodeLabel' | transloco"
                         [subLabel]="'qboImportSettings.defaultTaxCodeSubLabel' | transloco: { brandName: brandingConfig.brandName }"
                         [destinationAttributes]="taxCodes"
                         [optionLabel]="'name'"


### PR DESCRIPTION
### Description
qbo import settings transloco content

<img width="874" height="229" alt="Screenshot 2025-09-25 at 2 55 14 PM" src="https://github.com/user-attachments/assets/c6886184-8a85-4468-913e-9f9d24ad9b10" />


## Clickup
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Corrected tax-related labels in QuickBooks Online Import Settings to use the appropriate translation keys for “Tax Code” and “Default Tax Code,” improving accuracy across locales.
  - Preserved existing helper text with app branding and selection guidance; no changes to form behavior or options.

- Style
  - Improved consistency of terminology between Import and Export settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->