### PR TITLE
fix: dashboard export summary button click not working

### DIFF
--- a/src/app/shared/components/dashboard/dashboard-error-section/dashboard-error-section.component.html
+++ b/src/app/shared/components/dashboard/dashboard-error-section/dashboard-error-section.component.html
@@ -89,7 +89,7 @@
                             </h5></div>
                             <div class="flex-wrapper" [ngClass]="brandingStyle.dashboard.exportErrorCardButton">
                                 <div>
-                                    <app-button [buttonSize]="ButtonSize.EXTRA_SMALL" [buttonType]="ButtonType.SECONDARY" [buttonText]="'common.viewExpenseText' | transloco"></app-button>
+                                    <app-button [buttonSize]="ButtonSize.EXTRA_SMALL" [buttonType]="ButtonType.SECONDARY" (buttonClick)="showErrorDialog(error)" [buttonText]="'common.viewExpenseText' | transloco"></app-button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### Description
dashboard export summary button click not working

## Clickup
https://app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The primary action button on the Accounting Error card now opens the error dialog when clicked. Previously, the button had no effect. This update provides immediate access to error details and guidance without changing the visual appearance. It improves interaction consistency across error cards and reduces user friction when addressing accounting-related issues on the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->